### PR TITLE
feat: task_number連番 + artifacts標準ディレクトリ + .gitignore整備 #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.log
 .mcp.json
 .claude/settings.local.json
+.DS_Store
+**/.DS_Store
+.summonai/
+summonai_memory.db*

--- a/instructions/executor.md
+++ b/instructions/executor.md
@@ -49,6 +49,8 @@ Do not load unrelated conversation history by default.
 - Re-read outputs
 - Summarize results factually
 - Call `task_complete(task_id=..., summary=..., artifact_paths=[...], verification=...)`
+- **成果物は `.summonai/artifacts/<task_id>/` 以下に置くこと。**
+  `artifact_paths` に渡すパスは `.summonai/artifacts/` から始まる相対パスでなければならない（空リストは許容）。
 
 ## Commit Rules
 


### PR DESCRIPTION
## Summary

- `tasks.task_number` カラム追加（V004マイグレーション）。project-scoped 連番で `#1`, `#2` 形式で参照可能に
- `task_complete` / `task_update` の `artifact_paths` に `.summonai/artifacts/` 配下以外を渡すと `ValueError`
- `instructions/executor.md` に成果物ディレクトリ規約を追記
- `.gitignore` に `.DS_Store`, `**/.DS_Store`, `.summonai/`, `summonai_memory.db*` を追加

## Test plan

- [x] pytest 32 passed, 0 skipped
- [x] task_number 採番テスト（新規 ×2）
- [x] artifact_paths バリデーションテスト（×4）

Closes summonai-task-mcp#6

🤖 Generated with [Claude Code](https://claude.com/claude-code)