### PR TITLE
feat: task_number連番 + artifacts標準ディレクトリ + submodule main更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.log
 .mcp.json
 .claude/settings.local.json
+.DS_Store
+**/.DS_Store
+.summonai/
+summonai_memory.db*

--- a/instructions/executor.md
+++ b/instructions/executor.md
@@ -49,6 +49,8 @@ Do not load unrelated conversation history by default.
 - Re-read outputs
 - Summarize results factually
 - Call `task_complete(task_id=..., summary=..., artifact_paths=[...], verification=...)`
+- **成果物は `.summonai/artifacts/<task_id>/` 以下に置くこと。**
+  `artifact_paths` に渡すパスは `.summonai/artifacts/` から始まる相対パスでなければならない（空リストは許容）。
 
 ## Commit Rules
 


### PR DESCRIPTION
## Summary

- `tasks.task_number` カラム追加（V004マイグレーション）。project-scoped 連番で参照可能に
- `task_complete` / `task_update` の `artifact_paths` に `.summonai/artifacts/` 配下以外を渡すと `ValueError`
- `instructions/executor.md` に成果物ディレクトリ規約を追記
- `.gitignore` に `.DS_Store`, `.summonai/`, `summonai_memory.db*` を追加
- task-mcp サブモジュールポインタを main HEAD (21ddbab) に更新

## Test plan

- [x] summonai-task-mcp: 52 passed, 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)