### PR TITLE
fix: stop/session-start hookのパスを修正

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "SUMMONAI_AGENT_ID=summonai bash memory-mcp/scripts/session_start_memory_context.sh",
+            "command": "SUMMONAI_AGENT_ID=summonai bash /Users/smitsuhashi/ghq/github.com/mitsuha-sh/summonai/memory-mcp/scripts/session_start_memory_context.sh",
             "timeout": 15
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "SUMMONAI_AGENT_ID=summonai bash memory-mcp/scripts/stop_hook_conversation_save.sh",
+            "command": "SUMMONAI_AGENT_ID=summonai bash /Users/smitsuhashi/ghq/github.com/mitsuha-sh/summonai/memory-mcp/scripts/stop_hook_conversation_save.sh",
             "timeout": 15
           }
         ]


### PR DESCRIPTION
## Summary

- `.claude/settings.json` の SessionStart/Stop フックコマンドが相対パスを使用していた
- Claude Code がプロジェクトルート以外のディレクトリからフックを実行した際に `No such file or directory` が発生
- 両コマンドを絶対パスに修正

## Root cause

スクリプト自体は存在していたが、パスの解決に失敗していた。グローバル設定（`~/.claude/settings.json`）と同様の絶対パス形式に統一。

## Test plan

- [x] スクリプト直接実行 → exit code 0 確認済み
- [ ] セッション終了時に Stop hook エラーが出ないことを確認（次回セッションで検証）

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)