### PR TITLE
feat: Interface/Executor stacked pane レイアウト #5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,17 @@ start:
 		echo "Error: zellij is not installed. Run 'make setup' first and install zellij."; \
 		exit 1; \
 	}
-	@zellij kill-session summonai 2>/dev/null || true; \
-	zellij delete-session summonai 2>/dev/null || true; \
-	zellij --session summonai --new-session-with-layout "$(CURDIR)/zellij/layouts/summonai-start.kdl"
+	@command -v claude >/dev/null 2>&1 || { \
+		echo "Error: claude CLI is not installed."; \
+		exit 1; \
+	}
+	@if zellij list-sessions -n 2>/dev/null | grep -Fxq "summonai"; then \
+		echo "Attaching existing zellij session: summonai"; \
+		exec zellij attach summonai; \
+	else \
+		echo "Creating zellij session: summonai"; \
+		exec zellij --session summonai --new-session-with-layout "$(CURDIR)/zellij/layouts/summonai-start.kdl"; \
+	fi
 
 stop:
 	@zellij kill-session summonai 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ This repository keeps the setup entrypoint and delegates operational details (ru
 
 ## Start Workflow
 
-- `make start` uses `zellij attach --create summonai` behavior.
+- `make start` checks whether zellij session `summonai` already exists.
 - If session `summonai` does not exist, it is created with layout `zellij/layouts/summonai-start.kdl` and the main pane starts `claude` in interactive mode.
-- If session `summonai` already exists, `make start` attaches to that session (no duplicate session).
+- If session `summonai` already exists, `make start` attaches to that session as-is (no duplicate session).
 
 ## Notes
 

--- a/config/task_runner.claude.json
+++ b/config/task_runner.claude.json
@@ -1,5 +1,6 @@
 {
   "enabled": true,
-  "project_dir": ".",
-  "runner": "claude"
+  "project_dir": "/Users/smitsuhashi/ghq/github.com/mitsuha-sh/summonai",
+  "runner": "claude",
+  "executor_stack": false
 }

--- a/config/task_runner.claude.json
+++ b/config/task_runner.claude.json
@@ -1,6 +1,6 @@
 {
   "enabled": true,
-  "project_dir": "/Users/smitsuhashi/ghq/github.com/mitsuha-sh/summonai",
+  "project_dir": ".",
   "runner": "claude",
   "executor_stack": false
 }

--- a/zellij/layouts/summonai-start.kdl
+++ b/zellij/layouts/summonai-start.kdl
@@ -1,10 +1,10 @@
 layout {
     pane split_direction="horizontal" {
-        pane size=55 name="interface" command="claude" {
+        pane size="55%" name="interface" command="claude" {
             args "--dangerously-skip-permissions"
         }
-        pane size=45 stacked=true {
-            pane name="executor-anchor"
+        pane size="45%" {
+            pane name="executor-anchor" command="zsh"
         }
     }
 }

--- a/zellij/layouts/summonai-start.kdl
+++ b/zellij/layouts/summonai-start.kdl
@@ -1,5 +1,10 @@
 layout {
-    pane command="claude" {
-        args "--dangerously-skip-permissions"
+    pane split_direction="horizontal" {
+        pane size=55 name="interface" command="claude" {
+            args "--dangerously-skip-permissions"
+        }
+        pane size=45 stacked=true {
+            pane name="executor-anchor"
+        }
     }
 }

--- a/zellij/layouts/summonai-start.kdl
+++ b/zellij/layouts/summonai-start.kdl
@@ -1,8 +1,6 @@
 layout {
     pane split_direction="horizontal" {
-        pane size="55%" name="interface" command="claude" {
-            args "--dangerously-skip-permissions"
-        }
+        pane size="55%" name="interface" command="claude"
         pane size="45%" {
             pane name="executor-anchor" command="zsh"
         }


### PR DESCRIPTION
## Summary
- summonai-start.kdl を左右分割レイアウトに更新（interface 左55% / executor-anchor 右45%）
- pane.py に find_pane_by_name / focus_pane / create_pane_in_stack を追加
- server.py に executor_stack 対応（anchor検索→stacked追加、fallback付き）
- config/task_runner.claude.json に executor_stack オプション追加
- Makefile: 既存zellijセッションへのattach対応

## Fix
- task_runner.claude.json の project_dir をハードコード絶対パスから `"."` に修正