### PR TITLE
chore(layout): remove executor-anchor pane from summonai-start.kdl

### DIFF
--- a/zellij/layouts/summonai-start.kdl
+++ b/zellij/layouts/summonai-start.kdl
@@ -1,8 +1,3 @@
 layout {
-    pane split_direction="horizontal" {
-        pane size="55%" name="interface" command="claude"
-        pane size="45%" {
-            pane name="executor-anchor" command="zsh"
-        }
-    }
+    pane name="interface" command="claude"
 }


### PR DESCRIPTION
## Summary

- `zellij/layouts/summonai-start.kdl` から `executor-anchor` pane と不要な horizontal split container を削除
- task-011 で executor 起動が `create_tab` 方式に移行済みのため、placeholder pane は不要
- layout を interface 単一 pane のシンプルな構成に変更

## Changes

- Before: `interface` + `executor-anchor` の horizontal split 2pane 構成
- After: `interface` 単一 pane 構成

## Test plan

- [ ] `server.py` / `pane.py` に `executor-anchor` 参照がないことを確認済み（grep で検索、0件）
- [ ] `make start` 相当で起動しても余分な zsh pane が開かないことをレイアウトファイルで確認
- [ ] task-mcp pytest tests/ -x: 60 passed, 0 skipped

Closes task-013

🤖 Generated with [Claude Code](https://claude.com/claude-code)