### PR TITLE
feat: tab-based zellij layout with config, keybindings, and go_to_tab fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ start:
 		exec zellij attach summonai; \
 	else \
 		echo "Creating zellij session: summonai"; \
-		exec zellij --session summonai --new-session-with-layout "$(CURDIR)/zellij/layouts/summonai-start.kdl"; \
+		exec zellij --session summonai --config "$(CURDIR)/zellij/config/summonai.kdl" --new-session-with-layout "$(CURDIR)/zellij/layouts/summonai-start.kdl"; \
 	fi
 
 stop:

--- a/zellij/config/summonai.kdl
+++ b/zellij/config/summonai.kdl
@@ -1,0 +1,47 @@
+// SummonAI — zellij configuration
+// Tab bar is enabled by default; this file locks it on and defines
+// the key bindings used when managing interface / executor tabs.
+
+themes {
+    default {
+        fg 238 238 238
+        bg 28 28 28
+        black 28 28 28
+        red 204 102 102
+        green 102 153 102
+        yellow 230 179 102
+        blue 102 153 204
+        magenta 178 102 204
+        cyan 102 204 204
+        white 238 238 238
+        orange 204 153 102
+    }
+}
+
+ui {
+    pane_frames {
+        rounded_corners true
+    }
+}
+
+// Always show the tab bar so the active tab name is visible.
+simplified_ui false
+
+keybinds clear-defaults=false {
+    // Tab navigation — move between interface and executor tabs
+    shared_except "locked" {
+        bind "Alt 1" { GoToTab 1; }
+        bind "Alt 2" { GoToTab 2; }
+        bind "Alt 3" { GoToTab 3; }
+        bind "Alt 4" { GoToTab 4; }
+        bind "Alt 5" { GoToTab 5; }
+        bind "Alt h" { GoToPreviousTab; }
+        bind "Alt l" { GoToNextTab; }
+
+        // Pane focus movement
+        bind "Alt Left"  { MoveFocusOrTab "Left"; }
+        bind "Alt Right" { MoveFocusOrTab "Right"; }
+        bind "Alt Up"    { MoveFocus "Up"; }
+        bind "Alt Down"  { MoveFocus "Down"; }
+    }
+}

--- a/zellij/layouts/summonai-start.kdl
+++ b/zellij/layouts/summonai-start.kdl
@@ -1,8 +1,7 @@
 layout {
-    pane split_direction="horizontal" {
-        pane size="55%" name="interface" command="claude"
-        pane size="45%" {
-            pane name="executor-anchor" command="zsh"
+    tab name="interface" {
+        pane command="claude" {
+            args "--dangerously-skip-permissions"
         }
     }
 }


### PR DESCRIPTION
## Summary

- `zellij/layouts/summonai-start.kdl`: convert to `tab name="interface"` structure so `go_to_tab("interface")` resolves correctly — this was the root cause of executor focus restoration always failing
- Remove `executor-anchor` pane (executors spawn as dynamic tabs)
- Add `claude --dangerously-skip-permissions` to interface pane
- `zellij/config/summonai.kdl`: new config enabling tab bar + Alt+h/l / Alt+1-5 keybindings
- `Makefile`: add `--config` flag so the config is loaded on `make start`
- `task-mcp` submodule bump: graceful `go_to_tab` fallback + multi-pane tab creation fix

Closes #12 (supersedes feature/013 PR).

## Test plan

- [ ] `pytest tests/ -x` in task-mcp — 60 passed, 0 skipped
- [ ] `make start` launches zellij with tab bar showing "interface" tab
- [ ] Executor spawn creates a new tab; focus returns to "interface"
- [ ] Alt+h / Alt+l navigate between tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)