### PR TITLE
feat(layout): add tab-bar and status-bar plugins to summonai-start.kdl

### DIFF
--- a/zellij/layouts/summonai-start.kdl
+++ b/zellij/layouts/summonai-start.kdl
@@ -1,7 +1,13 @@
 layout {
+    pane size=1 borderless=true {
+        plugin location="zellij:tab-bar"
+    }
     tab name="interface" {
         pane command="claude" {
             args "--dangerously-skip-permissions"
         }
+    }
+    pane size=2 borderless=true {
+        plugin location="zellij:status-bar"
     }
 }


### PR DESCRIPTION
## Summary

- `zellij/layouts/summonai-start.kdl` に `zellij:tab-bar`（size=1 borderless=true）を追加
- `zellij/layouts/summonai-start.kdl` に `zellij:status-bar`（size=2 borderless=true）を追加
- `tab name="interface"` の `claude` pane 構成は維持

## Background

task 014 では tab-bar / status-bar を `zellij/config/summonai.kdl` の設定に依存させていた。
zellij は既存セッションへの attach 時に `--config` を渡せないため、古いセッションではタブバーが表示されない問題があった。

layout ファイルに直接埋め込むことで `--config` の有無に関係なく常に表示される。

## Test plan

- [ ] `zellij --new-session-with-layout zellij/layouts/summonai-start.kdl`（`--config` なし）でタブバーが表示される
- [ ] `make start` でステータスバーにキーバインドヒントが表示される
- [ ] `tab name="interface"` で claude が起動している

Closes task #016

🤖 Generated with [Claude Code](https://claude.com/claude-code)