### PR TITLE
feat: add .worktrees/ to gitignore and update task-mcp submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 **/.DS_Store
 .summonai/
 summonai_memory.db*
+.worktrees/


### PR DESCRIPTION
## Summary

- Add `.worktrees/` to `.gitignore` so git worktree directories are not tracked
- Update `task-mcp` submodule pointer to [fdde656](https://github.com/mitsuha-sh/summonai-task-mcp/commit/fdde656) which adds `needs_worktree` opt-in flag (see mitsuha-sh/summonai-task-mcp#15)

## Test plan

- [ ] `git submodule status` shows updated task-mcp pointer
- [ ] `.worktrees/` appears in `.gitignore`
- [ ] summonai-task-mcp#15 is merged before merging this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)