### PR TITLE
chore(task-mcp): bump submodule for task_list summary+exclude_status (feat/017)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Detailed interface operating rules are defined in `instructions/interface.md`.
 |----|--------|------------|
 | F001 | Execute tasks yourself (write code, create files, run builds) | `task_create` with assignee |
 | F002 | Run polling loops to check task status | User asks, or check once with `task_get` |
+| F007 | Call `task_list` without `summary=True` for routine status checks | Use `task_list(summary=True, exclude_status=["done","cancelled"])` |
 | F003 | Skip reading CLAUDE.md / persona on session start | Always read on startup |
 | F004 | Guess when you can look up | (1) memory_search → (2) read code/reports → (3) ask user |
 | F005 | Overstate progress or treat unverified work as complete | Report factually |

--- a/instructions/interface.md
+++ b/instructions/interface.md
@@ -190,3 +190,24 @@ Read:
 Avoid by default:
 - executor scratch details irrelevant to review
 - unrelated projects or stale task artifacts
+
+## task_list Usage Rules
+
+`task_list` returns full task objects by default (~10k tokens for many tasks).
+Always use lightweight options to avoid context pollution:
+
+```python
+# Daily status check — use this by default
+task_list(summary=True, exclude_status=["done", "cancelled"])
+
+# Filter to a project or specific status when scope is clear
+task_list(summary=True, project="summonai", exclude_status=["done", "cancelled"])
+
+# Full detail only when you need purpose/acceptance_criteria for review
+task_list(status="review")
+```
+
+Rules:
+- **Default call must include `summary=True`** unless full detail is specifically needed
+- **Include `exclude_status=["done", "cancelled"]`** unless you explicitly need completed tasks
+- Use `task_get(task_id)` for per-task detail, not a full `task_list`


### PR DESCRIPTION
## Summary
- task-mcp サブモジュールポインタを `c9e3041` → `98e31f9` に更新
- summonai-task-mcp#17 (task_list summary mode / exclude_status) に対応

## Dependencies
- **マージ順序**: summonai-task-mcp#17 をマージ後にこちらをマージすること

## Test plan
- [x] サブモジュールポインタが feature/017 コミットを指していることを確認
- [x] 依存PRのテスト: 72 passed, no skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)