### PR TITLE
feat(bloom-routing): Bloom-based executor model routing (Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,51 @@ Edit the `persona_dir` in `.summonai/memory.toml` to point at the single source 
 
 For dogfooding across multiple projects, point each project's `.summonai/memory.toml` at the same `persona_dir` and use the same `agent_id`. Keep real persona files private; commit only examples.
 
+## Bloom-based Executor Model Routing
+
+Each task has two optional fields that control which Claude model the executor uses:
+
+- **`bloom_level`** (integer 1–6, default 3): cognitive complexity of the task, based on [Bloom's Taxonomy](https://en.wikipedia.org/wiki/Bloom%27s_taxonomy).
+  - 1 = Remember, 2 = Understand, 3 = Apply, 4 = Analyze, 5 = Evaluate, 6 = Create
+- **`executor`** (string, optional): explicit executor tier name (e.g. `"haiku"`, `"sonnet"`, `"opus"`). If omitted, the cheapest tier that covers `bloom_level` is selected automatically.
+
+### Setup
+
+`make setup` (or `setup.sh`) copies `config/executors.toml.example` to `.summonai/executors.toml` on first run. Edit `.summonai/executors.toml` to configure your capability tiers and runner templates. This file is git-ignored.
+
+### Example `config/executors.toml.example`
+
+```toml
+[[capability_tiers]]
+executor = "haiku"
+model = "claude-haiku-4-5-20251001"
+max_bloom = 3
+cost_group = "low"
+
+[[capability_tiers]]
+executor = "sonnet"
+model = "claude-sonnet-4-6"
+max_bloom = 5
+cost_group = "medium"
+
+[[capability_tiers]]
+executor = "opus"
+model = "claude-opus-4-7"
+max_bloom = 6
+cost_group = "high"
+
+[runners.default]
+template = "claude --model {model} --dangerously-skip-permissions"
+```
+
+### Selection Logic
+
+1. Filter tiers by `executor` if specified; otherwise consider all tiers.
+2. Keep tiers with `max_bloom >= bloom_level`.
+3. From remaining tiers, pick the one with the smallest `max_bloom` (cheapest).
+4. If no tier covers the bloom_level (coverage gap), fall back to the tier with the largest `max_bloom` and emit a `WARN` to stderr.
+5. If no executors.toml is present, the default `claude --dangerously-skip-permissions` command is used unchanged.
+
 ## Task Runner
 
 Default runner is `config/task_runner.claude.json` (Claude Code). To change, update `SUMMONAI_TASK_RUNNER_CONFIG` in `.mcp.json`.

--- a/config/executors.toml.example
+++ b/config/executors.toml.example
@@ -1,0 +1,44 @@
+# Bloom-based executor capability tiers for summonai-task-mcp
+# Copy to .summonai/executors.toml and edit locally.
+# Do not commit .summonai/executors.toml (it is git-ignored).
+
+# capability_tiers: each entry maps an executor name to a Claude model.
+# max_bloom: the highest Bloom level (1-6) this tier can handle.
+#   1=Remember, 2=Understand, 3=Apply (default), 4=Analyze, 5=Evaluate, 6=Create
+# cost_group: informational label (low / medium / high).
+#
+# Selection rules:
+#   - When task.executor is specified: pick the tier with that executor name
+#     whose max_bloom >= task.bloom_level (cheapest first).
+#   - When task.executor is unspecified: pick the cheapest (smallest max_bloom)
+#     tier whose max_bloom >= task.bloom_level across all tiers.
+#   - Coverage gap (no tier covers bloom_level): fall back to the tier with the
+#     largest max_bloom and emit a WARN to stderr.
+
+[[capability_tiers]]
+executor = "haiku"
+model = "claude-haiku-4-5-20251001"
+max_bloom = 3
+cost_group = "low"
+
+[[capability_tiers]]
+executor = "sonnet"
+model = "claude-sonnet-4-6"
+max_bloom = 5
+cost_group = "medium"
+
+[[capability_tiers]]
+executor = "opus"
+model = "claude-opus-4-7"
+max_bloom = 6
+cost_group = "high"
+
+# runners: how to launch a Claude executor.
+# {model} is replaced with the selected tier's model value.
+# Executor-specific runners take precedence over "default".
+
+[runners.default]
+template = "claude --model {model} --dangerously-skip-permissions"
+
+# [runners.haiku]
+# template = "claude --model {model} --dangerously-skip-permissions"

--- a/reports/019_bloom_routing_phase1.md
+++ b/reports/019_bloom_routing_phase1.md
@@ -3,7 +3,7 @@
 ## PR URLs
 
 - **task-mcp PR**: https://github.com/mitsuha-sh/summonai-task-mcp/pull/19
-- **summonai PR**: (see below — created from this branch)
+- **summonai PR**: https://github.com/mitsuha-sh/summonai/pull/18
 
 ## Migration Procedure
 

--- a/reports/019_bloom_routing_phase1.md
+++ b/reports/019_bloom_routing_phase1.md
@@ -1,0 +1,93 @@
+# Report: Bloom-based Executor Model Routing (Phase 1) — Task 019
+
+## PR URLs
+
+- **task-mcp PR**: https://github.com/mitsuha-sh/summonai-task-mcp/pull/19
+- **summonai PR**: (see below — created from this branch)
+
+## Migration Procedure
+
+Migration `V006_add_bloom_level_executor.sql` is automatically applied on server startup via `ensure_schema()`. No manual intervention required.
+
+```sql
+ALTER TABLE tasks ADD COLUMN bloom_level INTEGER NOT NULL DEFAULT 3;
+ALTER TABLE tasks ADD COLUMN executor TEXT;
+```
+
+Existing tasks receive `bloom_level=3` (Apply) and `executor=NULL` (auto-select), preserving existing behavior.
+
+## Selection Logic (Pseudocode)
+
+```python
+def select_model_tier(bloom_level, executor, tiers):
+    # Filter by executor name if specified
+    candidates = [t for t in tiers if t.executor == executor] if executor else tiers
+
+    # Find tiers that cover the bloom level
+    covering = [t for t in candidates if t.max_bloom >= bloom_level]
+
+    if covering:
+        # Cheapest = smallest max_bloom
+        return min(covering, key=lambda t: t.max_bloom), is_gap=False
+    else:
+        # Coverage gap: use largest max_bloom as fallback
+        fallback_pool = candidates if candidates else tiers
+        return max(fallback_pool, key=lambda t: t.max_bloom), is_gap=True
+
+def build_executor_command(tier, runners, is_gap, bloom_level):
+    if tier is None:
+        return "claude --dangerously-skip-permissions"  # no config
+    if is_gap:
+        WARN to stderr: "bloom_level={} exceeds max_bloom ..."
+    runner = runners.get(tier.executor) or runners.get("default")
+    if runner:
+        return runner.template.replace("{model}", tier.model)
+    return f"claude --model {tier.model} --dangerously-skip-permissions"
+```
+
+## Manual Verification: Sample capability_tiers Model Selection
+
+Given `config/executors.toml.example` with haiku (max_bloom=3), sonnet (max_bloom=5), opus (max_bloom=6):
+
+| bloom_level | executor  | Selected tier | is_gap | Command                                                    |
+|-------------|-----------|---------------|--------|------------------------------------------------------------|
+| 2           | None      | haiku         | False  | `claude --model claude-haiku-4-5-20251001 ...`             |
+| 3           | None      | haiku         | False  | `claude --model claude-haiku-4-5-20251001 ...`             |
+| 4           | None      | sonnet        | False  | `claude --model claude-sonnet-4-6 ...`                     |
+| 6           | None      | opus          | False  | `claude --model claude-opus-4-7 ...`                       |
+| 7           | None      | opus          | True   | WARN + `claude --model claude-opus-4-7 ...`                |
+| 3           | "sonnet"  | sonnet        | False  | `claude --model claude-sonnet-4-6 ...`                     |
+| 6           | "haiku"   | haiku         | True   | WARN + `claude --model claude-haiku-4-5-20251001 ...`      |
+| 3           | None      | (no config)   | N/A    | `claude --dangerously-skip-permissions` (legacy)           |
+
+## Test Results
+
+- 77 pre-existing tests: all pass
+- 20 new tests added in `tests/test_server.py`:
+  - `test_select_model_tier_*` (6 cases): unit tests for tier selection logic
+  - `test_build_executor_command_*` (4 cases): command building with gap WARN
+  - `test_task_create_stores_bloom_level_and_executor`: DB storage verified
+  - `test_task_create_default_bloom_level`: default value = 3
+  - `test_task_create_rejects_invalid_bloom_level`: bloom_level=7 rejected
+  - `test_load_executors_config_*` (3 cases): TOML loading from env/dir/missing
+  - `test_spawn_uses_bloom_model_selection`: integration test with haiku selection
+  - `test_spawn_bloom_gap_uses_fallback`: integration test with gap fallback
+  - `test_schema_includes_bloom_level_executor`: migration V006 applied
+
+Total: **97 tests, all passing**.
+
+## Files Changed
+
+### task-mcp
+
+- `src/summonai_task/db/migrations/V006_add_bloom_level_executor.sql` — new migration
+- `src/summonai_task/server.py` — TOML loading, selection logic, command building, updated API
+- `tests/test_server.py` — 20 new tests
+
+### summonai
+
+- `config/executors.toml.example` — public TOML template (no absolute paths / personal data)
+- `setup.sh` — generates `.summonai/executors.toml`, passes `SUMMONAI_EXECUTORS_CONFIG` env var to MCP
+- `README.md` — Bloom routing section added near Persona
+- `task-mcp` — submodule pointer updated to bloom-routing commit
+- `reports/019_bloom_routing_phase1.md` — this report

--- a/setup.sh
+++ b/setup.sh
@@ -44,10 +44,13 @@ claude mcp add -s project \
   -e SUMMONAI_MEMORY_DB="$MEMORY_DB" \
   -- "$VENV_DIR/bin/python" "$MEMORY_MCP_DIR/server.py"
 
+EXECUTORS_CONFIG="$ROOT_DIR/.summonai/executors.toml"
+
 claude mcp add -s project \
   summonai-task-mcp \
   -e SUMMONAI_TASK_DB="$TASK_DB" \
   -e SUMMONAI_TASK_RUNNER_CONFIG="$RUNNER_CONFIG" \
+  -e SUMMONAI_EXECUTORS_CONFIG="$EXECUTORS_CONFIG" \
   -- uv run --directory "$ROOT_DIR/task-mcp" python -m summonai_task.server
 
 # ── 5. Task runner config ──
@@ -67,7 +70,7 @@ else
   echo "Skipped (exists): $RUNNER_CONFIG"
 fi
 
-# ── 6. Project-local memory hook config ──
+# ── 6. Project-local memory hook config and executors config ──
 mkdir -p "$ROOT_DIR/.summonai" "$ROOT_DIR/personas/default"
 MEMORY_CONFIG="$ROOT_DIR/.summonai/memory.toml"
 PERSONA_DIR="$ROOT_DIR/personas/default"
@@ -80,6 +83,13 @@ scope_id = "summonai"
 persona_dir = "$PERSONA_DIR"
 EOF
   echo "Created $MEMORY_CONFIG"
+fi
+
+if [ ! -f "$EXECUTORS_CONFIG" ]; then
+  cp "$ROOT_DIR/config/executors.toml.example" "$EXECUTORS_CONFIG"
+  echo "Created $EXECUTORS_CONFIG (edit to customize capability tiers)"
+else
+  echo "Skipped (exists): $EXECUTORS_CONFIG"
 fi
 
 # ── 7. Hooks (SessionStart + Stop) ──
@@ -134,6 +144,7 @@ echo "- Memory hook config: .summonai/memory.toml"
 echo "- Persona source: $PERSONA_DIR"
 echo "- Memory venv: memory-mcp/.venv"
 echo "- Task runner: $RUNNER_CONFIG"
+echo "- Executor tiers: $EXECUTORS_CONFIG"
 echo ""
 echo "Start Claude Code:"
 echo "  cd $ROOT_DIR && claude"


### PR DESCRIPTION
## Summary

- `config/executors.toml.example`: public TOML template defining capability tiers (haiku/sonnet/opus) with `max_bloom`, `model`, `cost_group` and `runners.default.template`
- `setup.sh`: copies example to `.summonai/executors.toml` on first run; passes `SUMMONAI_EXECUTORS_CONFIG` env var to MCP server so task-mcp can auto-select models
- `README.md`: new "Bloom-based Executor Model Routing" section near Persona — explains bloom_level (1-6), executor field, selection algorithm, and config example
- `task-mcp`: submodule bumped to feat(bloom-routing) commit (V006 migration + model selection + 20 new tests)
- `reports/019_bloom_routing_phase1.md`: migration steps, selection pseudocode, verification table, test results

## Related PR

- task-mcp: https://github.com/mitsuha-sh/summonai-task-mcp/pull/19

## Test plan

- [x] task-mcp: 97 pytest tests pass (77 existing + 20 new bloom routing tests)
- [x] `config/executors.toml.example` contains no absolute paths or personal data
- [x] `.summonai/` already in `.gitignore` — no new entry needed
- [x] setup.sh: `$EXECUTORS_CONFIG` defined before use, copy-on-first-run pattern consistent with memory.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)