### PR TITLE
fix(bloom-routing): executor = CLI tool name, [defaults] section, unknown executor rejection

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ For dogfooding across multiple projects, point each project's `.summonai/memory.
 
 ## Bloom-based Executor Model Routing
 
-Each task has two optional fields that control which Claude model the executor uses:
+Each task has two optional fields that control which CLI tool and model the executor uses:
 
 - **`bloom_level`** (integer 1–6, default 3): cognitive complexity of the task, based on [Bloom's Taxonomy](https://en.wikipedia.org/wiki/Bloom%27s_taxonomy).
   - 1 = Remember, 2 = Understand, 3 = Apply, 4 = Analyze, 5 = Evaluate, 6 = Create
-- **`executor`** (string, optional): explicit executor tier name (e.g. `"haiku"`, `"sonnet"`, `"opus"`). If omitted, the cheapest tier that covers `bloom_level` is selected automatically.
+- **`executor`** (string, optional): CLI tool name (e.g. `"claude"`, `"codex"`, `"opencode"`). If omitted, the cheapest tier that covers `bloom_level` is selected across all executors.
 
 ### Setup
 
@@ -73,26 +73,37 @@ Each task has two optional fields that control which Claude model the executor u
 ### Example `config/executors.toml.example`
 
 ```toml
+# executor = CLI tool name (claude / codex / opencode)
+# Multiple tiers share the same executor, ordered by max_bloom (cheapest first).
+
 [[capability_tiers]]
-executor = "haiku"
+executor = "claude"
 model = "claude-haiku-4-5-20251001"
 max_bloom = 3
 cost_group = "low"
 
 [[capability_tiers]]
-executor = "sonnet"
+executor = "claude"
 model = "claude-sonnet-4-6"
 max_bloom = 5
 cost_group = "medium"
 
 [[capability_tiers]]
-executor = "opus"
+executor = "claude"
 model = "claude-opus-4-7"
 max_bloom = 6
 cost_group = "high"
 
-[runners.default]
+[runners.claude]
 template = "claude --model {model} --dangerously-skip-permissions"
+
+# [runners.codex]
+# template = "codex --model {model}"
+
+# [defaults]: fallback values for task_create when bloom_level / executor are omitted.
+[defaults]
+bloom_level = 3
+# executor = "claude"
 ```
 
 ### Selection Logic
@@ -102,6 +113,12 @@ template = "claude --model {model} --dangerously-skip-permissions"
 3. From remaining tiers, pick the one with the smallest `max_bloom` (cheapest).
 4. If no tier covers the bloom_level (coverage gap), fall back to the tier with the largest `max_bloom` and emit a `WARN` to stderr.
 5. If no executors.toml is present, the default `claude --dangerously-skip-permissions` command is used unchanged.
+
+### Unknown executor rejection
+
+When `executors.toml` is present, passing an `executor` value not listed in any
+`[[capability_tiers]]` entry raises a `ValueError` that lists the available executor names.
+Environments without a config file accept any executor string (legacy / no-config mode).
 
 ## Task Runner
 

--- a/config/executors.toml.example
+++ b/config/executors.toml.example
@@ -2,7 +2,9 @@
 # Copy to .summonai/executors.toml and edit locally.
 # Do not commit .summonai/executors.toml (it is git-ignored).
 
-# capability_tiers: each entry maps an executor name to a Claude model.
+# capability_tiers: each entry maps an executor (CLI tool name) and a model.
+# executor: CLI tool name — e.g. "claude", "codex", "opencode".
+#   Multiple tiers with the same executor are ordered by max_bloom (cheapest first).
 # max_bloom: the highest Bloom level (1-6) this tier can handle.
 #   1=Remember, 2=Understand, 3=Apply (default), 4=Analyze, 5=Evaluate, 6=Create
 # cost_group: informational label (low / medium / high).
@@ -10,35 +12,44 @@
 # Selection rules:
 #   - When task.executor is specified: pick the tier with that executor name
 #     whose max_bloom >= task.bloom_level (cheapest first).
-#   - When task.executor is unspecified: pick the cheapest (smallest max_bloom)
-#     tier whose max_bloom >= task.bloom_level across all tiers.
+#   - When task.executor is unspecified: pick the cheapest tier across all
+#     executors whose max_bloom >= task.bloom_level.
 #   - Coverage gap (no tier covers bloom_level): fall back to the tier with the
 #     largest max_bloom and emit a WARN to stderr.
 
 [[capability_tiers]]
-executor = "haiku"
+executor = "claude"
 model = "claude-haiku-4-5-20251001"
 max_bloom = 3
 cost_group = "low"
 
 [[capability_tiers]]
-executor = "sonnet"
+executor = "claude"
 model = "claude-sonnet-4-6"
 max_bloom = 5
 cost_group = "medium"
 
 [[capability_tiers]]
-executor = "opus"
+executor = "claude"
 model = "claude-opus-4-7"
 max_bloom = 6
 cost_group = "high"
 
-# runners: how to launch a Claude executor.
+# runners: how to launch an executor by CLI tool name.
 # {model} is replaced with the selected tier's model value.
-# Executor-specific runners take precedence over "default".
+# runners.<executor> takes precedence over runners.default.
 
-[runners.default]
+[runners.claude]
 template = "claude --model {model} --dangerously-skip-permissions"
 
-# [runners.haiku]
-# template = "claude --model {model} --dangerously-skip-permissions"
+# [runners.codex]
+# template = "codex --model {model}"
+
+# [defaults]: fallback values used when task_create is called without
+# explicit bloom_level or executor.
+# bloom_level: default Bloom level (1-6) when unspecified. Falls back to 3.
+# executor: pin to a specific CLI tool. Omit to allow cross-executor selection.
+
+[defaults]
+bloom_level = 3
+# executor = "claude"

--- a/reports/task_020_bloom_routing_fix.md
+++ b/reports/task_020_bloom_routing_fix.md
@@ -30,11 +30,13 @@ tier ニックネーム（haiku/sonnet/opus）として使われており、「C
 - `[defaults]` セクションを読み込み、`defaults` キーで返す
 - `config_loaded` フラグを追加（ファイルが実在した場合 `True`）
 
-### task-mcp: task_create
+### task-mcp: task_create（初回コミット + Codex P1 修正）
 
-- defaults 適用: `bloom_level == 3`（デフォルト値）かつ `defaults.bloom_level` が設定されていれば上書き
-- defaults 適用: `executor is None` かつ `defaults.executor` が設定されていれば上書き
-- 未知 executor 拒否: `config_loaded=True` のときのみ、`capability_tiers` に存在しない executor 名を ValueError で拒否
+- **シグネチャ**: `bloom_level: int = 3` → `bloom_level: int | None = None`（sentinel 方式）
+- **defaults 適用**: `bloom_level is None` のときのみ `defaults.bloom_level` を適用、なければ 3 を確定
+  - ⚠️ 初回実装では `bloom_level == 3` で判定していたため、明示的に 3 を渡した場合も上書きされるバグがあった。Codex P1 指摘により sentinel 方式に修正。
+- **executor**: `executor is None` かつ `defaults.executor` が設定されていれば適用（変更なし）
+- **未知 executor 拒否**: `config_loaded=True` のときのみ、`capability_tiers` に存在しない executor 名を ValueError で拒否
 - エラーメッセージに利用可能な executor 名一覧を含む
 
 ---
@@ -62,15 +64,15 @@ executor = "claude"
 ```
 
 ```python
-task_create(title=..., ...)  # bloom_level/executor 未指定
-# → bloom_level=5, executor="claude" が適用される
+task_create(title=..., ...)          # bloom_level 未指定 → bloom_level=5, executor="claude"
+task_create(title=..., bloom_level=3)  # 明示的に 3 を指定 → bloom_level=3（defaults に上書きされない）
 ```
 
 ---
 
 ## テスト結果
 
-追加テスト 12 件（既存 81 件 + 追加 12 件 = 計 93 件、全件 pass）:
+追加テスト 14 件（既存 81 件 + 追加 14 件 = 計 95 件、全件 pass）:
 
 | テスト | 内容 |
 |--------|------|
@@ -80,11 +82,13 @@ task_create(title=..., ...)  # bloom_level/executor 未指定
 | `test_select_model_tier_same_executor_bloom6_picks_opus` | executor=claude + bloom_level=6 → opus |
 | `test_load_executors_config_reads_defaults` | [defaults] 読み込み確認 |
 | `test_load_executors_config_missing_config_loaded_false` | 設定なし → config_loaded=False |
-| `test_task_create_applies_defaults_bloom_level` | defaults.bloom_level 適用 |
-| `test_task_create_applies_defaults_executor` | defaults.executor 適用 |
+| `test_task_create_applies_defaults_bloom_level` | 未指定 → defaults.bloom_level 適用 |
+| `test_task_create_applies_defaults_executor` | 未指定 → defaults.executor 適用 |
 | `test_task_create_rejects_unknown_executor_when_config_loaded` | 未知 executor → ValueError |
 | `test_task_create_unknown_executor_error_lists_available` | エラーに一覧含む |
 | `test_task_create_accepts_unknown_executor_without_config` | 設定なし → 任意 executor OK |
+| `test_task_create_explicit_bloom3_not_overridden_by_defaults` | **明示的 bloom_level=3 は defaults で上書きされない** |
+| `test_task_create_unspecified_bloom_gets_defaults` | 未指定の場合は defaults が適用される |
 
 ---
 

--- a/reports/task_020_bloom_routing_fix.md
+++ b/reports/task_020_bloom_routing_fix.md
@@ -1,0 +1,94 @@
+# Task 020 — Bloom Routing Fix Report
+
+## 修正内容
+
+### 設計欠陥の内容
+task 019 で導入した bloom routing では `[[capability_tiers]].executor` フィールドが
+tier ニックネーム（haiku/sonnet/opus）として使われており、「CLIツール種別」という本来の意味と矛盾していた。
+
+### 修正方針
+`executor` = CLI ツール名（claude / codex / opencode）に意味論を統一。
+同一 executor 内で複数 tier を `max_bloom` で区別する構造に変更。
+
+---
+
+## 変更詳細
+
+### config/executors.toml.example（summonai リポ）
+
+- `[[capability_tiers]].executor` を `"claude"` に統一（3 tier: haiku / sonnet / opus モデル）
+- `[runners.default]` → `[runners.claude]` に変更。コメントで `[runners.codex]` 例を追加
+- `[defaults]` セクションを新規追加:
+  ```toml
+  [defaults]
+  bloom_level = 3
+  # executor = "claude"
+  ```
+
+### task-mcp: _load_executors_config
+
+- `[defaults]` セクションを読み込み、`defaults` キーで返す
+- `config_loaded` フラグを追加（ファイルが実在した場合 `True`）
+
+### task-mcp: task_create
+
+- defaults 適用: `bloom_level == 3`（デフォルト値）かつ `defaults.bloom_level` が設定されていれば上書き
+- defaults 適用: `executor is None` かつ `defaults.executor` が設定されていれば上書き
+- 未知 executor 拒否: `config_loaded=True` のときのみ、`capability_tiers` に存在しない executor 名を ValueError で拒否
+- エラーメッセージに利用可能な executor 名一覧を含む
+
+---
+
+## 未知 executor 拒否の動作
+
+```python
+# executors.toml が存在する場合
+task_create(..., executor="codex")  # capability_tiers に "codex" がなければ:
+# ValueError: Unknown executor: 'codex'. Available executors: ['claude']
+
+# executors.toml が存在しない場合（レガシー環境）
+task_create(..., executor="any-tool")  # OK — 検証スキップ
+```
+
+---
+
+## defaults 適用の動作
+
+```toml
+# .summonai/executors.toml
+[defaults]
+bloom_level = 5
+executor = "claude"
+```
+
+```python
+task_create(title=..., ...)  # bloom_level/executor 未指定
+# → bloom_level=5, executor="claude" が適用される
+```
+
+---
+
+## テスト結果
+
+追加テスト 12 件（既存 81 件 + 追加 12 件 = 計 93 件、全件 pass）:
+
+| テスト | 内容 |
+|--------|------|
+| `test_select_model_tier_same_executor_bloom2_picks_haiku` | executor=claude + bloom_level=2 → haiku |
+| `test_select_model_tier_same_executor_bloom4_picks_sonnet` | executor=claude + bloom_level=4 → sonnet |
+| `test_select_model_tier_same_executor_bloom5_picks_sonnet` | executor=claude + bloom_level=5 → sonnet |
+| `test_select_model_tier_same_executor_bloom6_picks_opus` | executor=claude + bloom_level=6 → opus |
+| `test_load_executors_config_reads_defaults` | [defaults] 読み込み確認 |
+| `test_load_executors_config_missing_config_loaded_false` | 設定なし → config_loaded=False |
+| `test_task_create_applies_defaults_bloom_level` | defaults.bloom_level 適用 |
+| `test_task_create_applies_defaults_executor` | defaults.executor 適用 |
+| `test_task_create_rejects_unknown_executor_when_config_loaded` | 未知 executor → ValueError |
+| `test_task_create_unknown_executor_error_lists_available` | エラーに一覧含む |
+| `test_task_create_accepts_unknown_executor_without_config` | 設定なし → 任意 executor OK |
+
+---
+
+## PR URLs
+
+- **task-mcp**: https://github.com/mitsuha-sh/summonai-task-mcp/pull/20
+- **summonai**: https://github.com/mitsuha-sh/summonai/pull/19


### PR DESCRIPTION
## Summary

- **executor semantics**: `executors.toml.example` updated so `executor` in `[[capability_tiers]]` is a CLI tool name (`claude` / `codex` / `opencode`), not a tier nickname. Three tiers share `executor = "claude"` and are differentiated by `max_bloom`.
- **[runners.claude]** added; commented `[runners.codex]` example included.
- **[defaults] section**: provides `bloom_level` and (commented) `executor` default, applied by `task_create` when caller omits them.
- **Unknown executor rejection**: documented in README; implemented in task-mcp submodule.
- **task-mcp submodule** bumped to `feature/bloom-routing-fix` (PR: https://github.com/mitsuha-sh/summonai-task-mcp/pull/20).

## Test plan

- [x] `config/executors.toml.example` has 3 `executor="claude"` tiers (haiku/sonnet/opus)
- [x] `[runners.claude]` present; `[runners.codex]` commented
- [x] `[defaults]` section with `bloom_level = 3` and commented `executor`
- [x] README Bloom Routing section reflects new semantics and unknown executor rejection
- [x] task-mcp submodule: 93 pytest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)