### PR TITLE
feat(zellij): add independent mobile session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,6 @@ start-mobile:
 		echo "Error: claude CLI is not installed."; \
 		exit 1; \
 	}
-	@if zellij list-sessions -n 2>/dev/null | grep -Fxq "summonai"; then \
-		echo "Detaching PC session: summonai"; \
-		ZELLIJ_SESSION_NAME=summonai zellij action detach 2>/dev/null || true; \
-	fi
 	@if zellij list-sessions -n 2>/dev/null | grep -Fxq "summonai-mobile"; then \
 		echo "Attaching existing zellij session: summonai-mobile"; \
 		exec zellij attach summonai-mobile; \

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ start-mobile:
 		echo "Error: claude CLI is not installed."; \
 		exit 1; \
 	}
+	@if zellij list-sessions -n 2>/dev/null | grep -Fxq "summonai"; then \
+		echo "Detaching PC session: summonai"; \
+		ZELLIJ_SESSION_NAME=summonai zellij action detach 2>/dev/null || true; \
+	fi
 	@if zellij list-sessions -n 2>/dev/null | grep -Fxq "summonai-mobile"; then \
 		echo "Attaching existing zellij session: summonai-mobile"; \
 		exec zellij attach summonai-mobile; \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: setup start stop
+.PHONY: setup start start-mobile stop stop-mobile
 
 setup:
 	bash setup.sh
@@ -22,7 +22,29 @@ start:
 		exec zellij --session summonai --config "$(CURDIR)/zellij/config/summonai.kdl" --new-session-with-layout "$(CURDIR)/zellij/layouts/summonai-start.kdl"; \
 	fi
 
+start-mobile:
+	@command -v zellij >/dev/null 2>&1 || { \
+		echo "Error: zellij is not installed. Run 'make setup' first and install zellij."; \
+		exit 1; \
+	}
+	@command -v claude >/dev/null 2>&1 || { \
+		echo "Error: claude CLI is not installed."; \
+		exit 1; \
+	}
+	@if zellij list-sessions -n 2>/dev/null | grep -Fxq "summonai-mobile"; then \
+		echo "Attaching existing zellij session: summonai-mobile"; \
+		exec zellij attach summonai-mobile; \
+	else \
+		echo "Creating zellij session with mobile layout: summonai-mobile"; \
+		exec zellij --session summonai-mobile --config "$(CURDIR)/zellij/config/summonai.kdl" --new-session-with-layout "$(CURDIR)/zellij/layouts/summonai-start-mobile.kdl"; \
+	fi
+
 stop:
 	@zellij kill-session summonai 2>/dev/null || true
 	@zellij delete-session summonai 2>/dev/null || true
 	@echo "summonai session stopped."
+
+stop-mobile:
+	@zellij kill-session summonai-mobile 2>/dev/null || true
+	@zellij delete-session summonai-mobile 2>/dev/null || true
+	@echo "summonai-mobile session stopped."

--- a/zellij/layouts/summonai-start-mobile.kdl
+++ b/zellij/layouts/summonai-start-mobile.kdl
@@ -1,0 +1,10 @@
+layout {
+    default_tab_template {
+        children
+    }
+    tab name="interface" {
+        pane command="claude" {
+            args "--dangerously-skip-permissions"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `start-mobile` を `summonai-mobile` セッション名に変更し、`summonai` と同時起動可能にした
- `stop-mobile` ターゲットを追加
- `zellij/layouts/summonai-start-mobile.kdl` を追加（interface pane 1つのスマホ向けレイアウト）

## Test plan
- [ ] `make start` で `summonai` セッション起動
- [ ] 別ターミナルで `make start-mobile` → `summonai-mobile` セッションが独立して起動すること
- [ ] `make stop-mobile` で `summonai-mobile` のみ停止し、`summonai` が生きていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)