### PR TITLE
feat(config): manage interface/executor models via executors.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 .claude/settings.json
 .DS_Store
 **/.DS_Store
-.summonai/
+.summonai/*
+!.summonai/executors.toml
 summonai_memory.db*
 .worktrees/
 personas/*/USER.md

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 **/.DS_Store
 .summonai/*
 !.summonai/executors.toml
+!.summonai/interface.toml
 summonai_memory.db*
 .worktrees/
 personas/*/USER.md

--- a/.summonai/executors.toml
+++ b/.summonai/executors.toml
@@ -1,0 +1,11 @@
+[defaults]
+bloom_level = 3
+executor = "claude"
+
+[interface]
+model = "claude-opus-4-6"
+
+[[capability_tiers]]
+executor = "claude"
+model = "claude-sonnet-4-6"
+max_bloom = 6

--- a/.summonai/executors.toml
+++ b/.summonai/executors.toml
@@ -2,9 +2,6 @@
 bloom_level = 3
 executor = "claude"
 
-[interface]
-model = "claude-opus-4-6"
-
 [[capability_tiers]]
 executor = "claude"
 model = "claude-sonnet-4-6"

--- a/.summonai/interface.toml
+++ b/.summonai/interface.toml
@@ -1,0 +1,2 @@
+[interface]
+model = "claude-opus-4-6"

--- a/scripts/start-interface.sh
+++ b/scripts/start-interface.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TOML="$SCRIPT_DIR/../.summonai/executors.toml"
+TOML="$SCRIPT_DIR/../.summonai/interface.toml"
 
 model=$(awk '/^\[interface\]/{found=1} found && /^model/{gsub(/.*= *"|"$/, ""); print; exit}' "$TOML")
 

--- a/scripts/start-interface.sh
+++ b/scripts/start-interface.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOML="$SCRIPT_DIR/../.summonai/executors.toml"
+
+model=$(awk '/^\[interface\]/{found=1} found && /^model/{gsub(/.*= *"|"$/, ""); print; exit}' "$TOML")
+
+if [[ -z "$model" ]]; then
+  echo "error: [interface].model not found in $TOML" >&2
+  exit 1
+fi
+
+exec claude --model "$model" --dangerously-skip-permissions

--- a/zellij/layouts/summonai-start.kdl
+++ b/zellij/layouts/summonai-start.kdl
@@ -9,8 +9,8 @@ layout {
         }
     }
     tab name="interface" {
-        pane command="claude" {
-            args "--dangerously-skip-permissions"
+        pane command="bash" {
+            args "scripts/start-interface.sh"
         }
     }
 }


### PR DESCRIPTION
## Summary

- `.summonai/executors.toml` に `[interface]` セクション (`model = "claude-opus-4-6"`) を追加
- `scripts/start-interface.sh` を新規作成 — TOMLから `[interface].model` を読み、`claude --model <model> --dangerously-skip-permissions` を exec
- `zellij/layouts/summonai-start.kdl` を `scripts/start-interface.sh` 経由起動に変更（`--model` 直書き廃止）
- `.gitignore` を `.summonai/*` + `!.summonai/executors.toml` に変更してファイルをトラッキング可能に

**Note:** `.summonai/memory.toml` は引き続き gitignore 対象（ローカル設定）。

## Test plan

- [ ] `make start` で zellij 起動 → interface タブが `claude-opus-4-6` で動作することを確認
- [ ] `scripts/start-interface.sh` を直接実行 → `exec claude --model claude-opus-4-6 --dangerously-skip-permissions` が呼ばれる
- [ ] `.claude/settings.json` に `model` フィールドが存在しないことを確認
- [ ] `.summonai/executors.toml` の `[[capability_tiers]]` が `claude-sonnet-4-6` / `max_bloom=6` であることを確認

Closes #026

🤖 Generated with [Claude Code](https://claude.com/claude-code)