### PR TITLE
fix: avoid Claude Code key conflicts in zellij mode switches

### DIFF
--- a/zellij/config/summonai.kdl
+++ b/zellij/config/summonai.kdl
@@ -28,15 +28,10 @@ ui {
 simplified_ui false
 
 keybinds clear-defaults=false {
-    // Disable default Ctrl mode-switch keys that conflict with Claude Code shortcuts.
-    unbind "Ctrl g"
-    unbind "Ctrl o"
-    unbind "Ctrl b"
-    unbind "Ctrl s"
-    unbind "Ctrl t"
-
     // Entry bindings (normal -> mode) remapped to Ctrl+Alt+key.
     shared_except "locked" {
+        // Scope unbind to the original shared mode-switch context only.
+        unbind "Ctrl g"
         bind "Ctrl Alt g" { SwitchToMode "Locked"; }
 
         // Tab navigation — move between interface and executor tabs
@@ -56,15 +51,23 @@ keybinds clear-defaults=false {
     }
 
     shared_except "session" "locked" {
+        unbind "Ctrl o"
         bind "Ctrl Alt o" { SwitchToMode "Session"; }
+    }
+    shared_except "tmux" "locked" "scroll" "search" {
+        unbind "Ctrl b"
     }
     shared_except "tmux" "locked" {
         bind "Ctrl Alt b" { SwitchToMode "Tmux"; }
+    }
+    shared_except "scroll" "locked" "search" "session" {
+        unbind "Ctrl s"
     }
     shared_except "scroll" "locked" {
         bind "Ctrl Alt s" { SwitchToMode "Scroll"; }
     }
     shared_except "tab" "locked" {
+        unbind "Ctrl t"
         bind "Ctrl Alt t" { SwitchToMode "Tab"; }
     }
 

--- a/zellij/config/summonai.kdl
+++ b/zellij/config/summonai.kdl
@@ -28,8 +28,18 @@ ui {
 simplified_ui false
 
 keybinds clear-defaults=false {
-    // Tab navigation — move between interface and executor tabs
+    // Disable default Ctrl mode-switch keys that conflict with Claude Code shortcuts.
+    unbind "Ctrl g"
+    unbind "Ctrl o"
+    unbind "Ctrl b"
+    unbind "Ctrl s"
+    unbind "Ctrl t"
+
+    // Entry bindings (normal -> mode) remapped to Ctrl+Alt+key.
     shared_except "locked" {
+        bind "Ctrl Alt g" { SwitchToMode "Locked"; }
+
+        // Tab navigation — move between interface and executor tabs
         bind "Alt 1" { GoToTab 1; }
         bind "Alt 2" { GoToTab 2; }
         bind "Alt 3" { GoToTab 3; }
@@ -43,5 +53,35 @@ keybinds clear-defaults=false {
         bind "Alt Right" { MoveFocusOrTab "Right"; }
         bind "Alt Up"    { MoveFocus "Up"; }
         bind "Alt Down"  { MoveFocus "Down"; }
+    }
+
+    shared_except "session" "locked" {
+        bind "Ctrl Alt o" { SwitchToMode "Session"; }
+    }
+    shared_except "tmux" "locked" {
+        bind "Ctrl Alt b" { SwitchToMode "Tmux"; }
+    }
+    shared_except "scroll" "locked" {
+        bind "Ctrl Alt s" { SwitchToMode "Scroll"; }
+    }
+    shared_except "tab" "locked" {
+        bind "Ctrl Alt t" { SwitchToMode "Tab"; }
+    }
+
+    // Exit bindings (mode -> normal) remapped to Ctrl+Alt+key.
+    locked {
+        bind "Ctrl Alt g" { SwitchToMode "Normal"; }
+    }
+    session {
+        bind "Ctrl Alt o" { SwitchToMode "Normal"; }
+    }
+    tmux {
+        bind "Ctrl Alt b" { Write 2; SwitchToMode "Normal"; }
+    }
+    scroll {
+        bind "Ctrl Alt s" { SwitchToMode "Normal"; }
+    }
+    tab {
+        bind "Ctrl Alt t" { SwitchToMode "Normal"; }
     }
 }


### PR DESCRIPTION
## Summary
- remap zellij mode-switch entry/exit keys from Ctrl+key to Ctrl+Alt+key for locked/session/tmux/scroll/tab
- explicitly unbind legacy Ctrl+G/O/B/S/T shortcuts because `clear-defaults=false`
- keep existing Alt-based tab/pane navigation bindings untouched

## Verification
- `zellij --config zellij/config/summonai.kdl setup --check` passes
- confirmed config includes 10 bidirectional mode-switch bindings (entry+exit across 5 modes)
- confirmed legacy `Ctrl+G/O/B/S/T` keys are explicitly unbound
- confirmed existing `Alt+1..5`, `Alt+h/l`, and `Alt+Arrow` bindings remain present
