### PR TITLE
fix: bloom routing CLI flags and mobile tab bar

### DIFF
--- a/.claude/skills/summonai-executor-config/SKILL.md
+++ b/.claude/skills/summonai-executor-config/SKILL.md
@@ -94,8 +94,7 @@ max_bloom = 6
 cost_group = "medium"
 
 [runners.codex]
-# Adjust flags to match your local Codex CLI setup (e.g. --approval-mode auto).
-template = "codex --model {model}"
+template = "codex --model {model} --search --dangerously-bypass-approvals-and-sandbox --no-alt-screen"
 
 [defaults]
 bloom_level = 3
@@ -124,8 +123,7 @@ max_bloom = 6
 cost_group = "high"
 
 [runners.codex]
-# Adjust flags to match your local Codex CLI setup (e.g. --approval-mode auto).
-template = "codex --model {model}"
+template = "codex --model {model} --search --dangerously-bypass-approvals-and-sandbox --no-alt-screen"
 
 [defaults]
 bloom_level = 3
@@ -169,8 +167,7 @@ cost_group = "high"
 template = "claude --model {model} --dangerously-skip-permissions"
 
 [runners.codex]
-# Adjust flags to match your local Codex CLI setup (e.g. --approval-mode auto).
-template = "codex --model {model}"
+template = "codex --model {model} --search --dangerously-bypass-approvals-and-sandbox --no-alt-screen"
 
 [defaults]
 bloom_level = 3

--- a/config/executors.toml.example
+++ b/config/executors.toml.example
@@ -43,7 +43,7 @@ cost_group = "high"
 template = "claude --model {model} --dangerously-skip-permissions"
 
 # [runners.codex]
-# template = "codex --model {model}"
+# template = "codex --model {model} --search --dangerously-bypass-approvals-and-sandbox --no-alt-screen"
 
 # [defaults]: fallback values used when task_create is called without
 # explicit bloom_level or executor.

--- a/config/task_runner.claude.json
+++ b/config/task_runner.claude.json
@@ -1,6 +1,6 @@
 {
   "enabled": true,
-  "project_dir": ".",
+  "project_dir": "..",
   "runner": "claude",
   "executor_stack": false,
   "max_concurrent_executors": 3

--- a/zellij/layouts/summonai-start-mobile.kdl
+++ b/zellij/layouts/summonai-start-mobile.kdl
@@ -1,5 +1,8 @@
 layout {
     default_tab_template {
+        pane size=1 borderless=true {
+            plugin location="zellij:tab-bar"
+        }
         children
     }
     tab name="interface" {


### PR DESCRIPTION
## Summary
- Codex executor テンプレートに `--search --dangerously-bypass-approvals-and-sandbox --no-alt-screen` フラグを追加（SKILL.md + executors.toml.example）
- `task_runner.claude.json` の `project_dir` を `.` → `..` に修正（task-mcp サブモジュール内からの相対パス修正）
- モバイルセッションレイアウトにタブバーを追加

## Test plan
- [ ] `zellij -l zellij/layouts/summonai-start-mobile.kdl` でタブバーが表示されること
- [ ] executor config スキルの出力テンプレートが正しいフラグを含むこと
- [ ] task_runner が正しい project_dir でタスクを検出すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)