### PR TITLE
fix: hide mobile zellij session name via official config option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ start-mobile:
 		exec zellij attach summonai-mobile; \
 	else \
 		echo "Creating zellij session with mobile layout: summonai-mobile"; \
-		exec zellij --session summonai-mobile --config "$(CURDIR)/zellij/config/summonai.kdl" --new-session-with-layout "$(CURDIR)/zellij/layouts/summonai-start-mobile.kdl"; \
+		exec zellij --session summonai-mobile --config "$(CURDIR)/zellij/config/summonai-mobile.kdl" --new-session-with-layout "$(CURDIR)/zellij/layouts/summonai-start-mobile.kdl"; \
 	fi
 
 stop:

--- a/zellij/config/summonai-mobile.kdl
+++ b/zellij/config/summonai-mobile.kdl
@@ -1,0 +1,82 @@
+// SummonAI — zellij configuration (mobile)
+// Derived from summonai.kdl. hide_session_name hides session name in compact-bar.
+
+themes {
+    default {
+        fg 238 238 238
+        bg 28 28 28
+        black 28 28 28
+        red 204 102 102
+        green 102 153 102
+        yellow 230 179 102
+        blue 102 153 204
+        magenta 178 102 204
+        cyan 102 204 204
+        white 238 238 238
+        orange 204 153 102
+    }
+}
+
+ui {
+    pane_frames {
+        rounded_corners true
+        hide_session_name true
+    }
+}
+
+keybinds clear-defaults=false {
+    shared_except "locked" {
+        unbind "Ctrl g"
+        bind "Ctrl Alt g" { SwitchToMode "Locked"; }
+
+        bind "Alt 1" { GoToTab 1; }
+        bind "Alt 2" { GoToTab 2; }
+        bind "Alt 3" { GoToTab 3; }
+        bind "Alt 4" { GoToTab 4; }
+        bind "Alt 5" { GoToTab 5; }
+        bind "Alt h" { GoToPreviousTab; }
+        bind "Alt l" { GoToNextTab; }
+
+        bind "Alt Left"  { MoveFocusOrTab "Left"; }
+        bind "Alt Right" { MoveFocusOrTab "Right"; }
+        bind "Alt Up"    { MoveFocus "Up"; }
+        bind "Alt Down"  { MoveFocus "Down"; }
+    }
+
+    shared_except "session" "locked" {
+        unbind "Ctrl o"
+        bind "Ctrl Alt o" { SwitchToMode "Session"; }
+    }
+    shared_except "tmux" "locked" "scroll" "search" {
+        unbind "Ctrl b"
+    }
+    shared_except "tmux" "locked" {
+        bind "Ctrl Alt b" { SwitchToMode "Tmux"; }
+    }
+    shared_except "scroll" "locked" "search" "session" {
+        unbind "Ctrl s"
+    }
+    shared_except "scroll" "locked" {
+        bind "Ctrl Alt s" { SwitchToMode "Scroll"; }
+    }
+    shared_except "tab" "locked" {
+        unbind "Ctrl t"
+        bind "Ctrl Alt t" { SwitchToMode "Tab"; }
+    }
+
+    locked {
+        bind "Ctrl Alt g" { SwitchToMode "Normal"; }
+    }
+    session {
+        bind "Ctrl Alt o" { SwitchToMode "Normal"; }
+    }
+    tmux {
+        bind "Ctrl Alt b" { Write 2; SwitchToMode "Normal"; }
+    }
+    scroll {
+        bind "Ctrl Alt s" { SwitchToMode "Normal"; }
+    }
+    tab {
+        bind "Ctrl Alt t" { SwitchToMode "Normal"; }
+    }
+}

--- a/zellij/layouts/summonai-start-mobile.kdl
+++ b/zellij/layouts/summonai-start-mobile.kdl
@@ -1,12 +1,12 @@
 layout {
     default_tab_template {
         pane size=1 borderless=true {
-            plugin location="zellij:tab-bar"
+            plugin location="zellij:compact-bar"
         }
         children
     }
     tab name="interface" {
-        pane command="claude" {
+        pane borderless=true command="claude" {
             args "--dangerously-skip-permissions"
         }
     }


### PR DESCRIPTION
## Summary
- switch `make start-mobile` to use dedicated `zellij/config/summonai-mobile.kdl`
- switch mobile top bar plugin from `tab-bar` to `compact-bar`
- add `hide_session_name true` under `ui.pane_frames` in `summonai-mobile.kdl`
- remove the previous `simplified_ui true` workaround

## Official basis (docs/source)
- Zellij official docs: `hide_session_name` option is the supported way to hide session name in UI
  - https://zellij.dev/documentation/options#hide_session_name
- Zellij API/source docs expose this as a dedicated mode update field (`update_hide_session_name`)
  - https://docs.rs/zellij-utils/latest/zellij_utils/data/struct.ModeInfo.html#method.update_hide_session_name

## Expected behavior
- `make start-mobile` starts with mobile config and layout
- mobile compact bar no longer shows session name (`summonai-mobile`)
- tabs (eg. interface/executor) continue to be shown by compact-bar

## Validation
- static verification only in this environment (no live `zellij` session attachment was possible here)
- diff scope is limited to:
  - `Makefile`
  - `zellij/layouts/summonai-start-mobile.kdl`
  - `zellij/config/summonai-mobile.kdl`