### PR TITLE
feat: switch mobile zellij bar to zjstatus tabs-only

### DIFF
--- a/zellij/layouts/summonai-start-mobile.kdl
+++ b/zellij/layouts/summonai-start-mobile.kdl
@@ -1,7 +1,18 @@
 layout {
     default_tab_template {
         pane size=1 borderless=true {
-            plugin location="zellij:compact-bar"
+            plugin location="https://github.com/dj95/zjstatus/releases/download/v0.23.0/zjstatus.wasm" {
+                format_left ""
+                format_center "{tabs}"
+                format_right ""
+                format_space ""
+
+                border_enabled "false"
+                hide_frame_for_single_pane "true"
+
+                tab_normal "#[fg=#6C7086] {name} "
+                tab_active "#[fg=#f9e2af,bold] {name} "
+            }
         }
         children
     }


### PR DESCRIPTION
## Summary
- replace mobile layout top bar plugin from `zellij:compact-bar` to `zjstatus`
- pin plugin location to the latest release used at implementation time: `v0.23.0`
- configure the bar to render only tabs (`{tabs}`), with empty left/right formats so mode/session (eg `NORMAL`, `Zellij`) are not shown

## Why
`compact-bar` cannot fully hide mode text and zellij branding in this layout. `zjstatus` lets us explicitly control visible widgets and keep only tab names.

## Verification
- confirmed release asset exists: `https://github.com/dj95/zjstatus/releases/download/v0.23.0/zjstatus.wasm`
- confirmed `summonai-start-mobile.kdl` no longer references `compact-bar`
- confirmed the configured widgets are tabs-only (`format_center = "{tabs}"`, empty `format_left/right`)

## Notes
- tab names (eg `interface`, `executor`) remain displayed via `{tabs}` widget
- this uses direct URL reference (not vendored wasm file) as allowed by task criteria
