### PR TITLE
feat: add Codex SessionStart hook for executor startup

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "SUMMONAI_DIR=\"$(git rev-parse --show-toplevel)\" SUMMONAI_MEMORY_CONFIG=\"$(git rev-parse --show-toplevel)/.summonai/memory.toml\" bash \"$(git rev-parse --show-toplevel)/scripts/hooks/session-start.sh\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ make start   # start/attach zellij session "summonai" and run claude in main pan
 5. Configures Claude Code hooks in `.claude/settings.json`:
    - **SessionStart**: injects persona (USER.md/SOUL.md), memory restore instructions
    - **Stop**: auto-saves conversation to memory DB
-6. Copies persona templates into the configured persona source if `USER.md`/`SOUL.md` don't exist yet
+6. Uses Codex hooks in `.codex/hooks.json`:
+   - **SessionStart**: injects the same startup context as Claude (`startup|resume|clear`)
+7. Copies persona templates into the configured persona source if `USER.md`/`SOUL.md` don't exist yet
 
 ## Prerequisites
 
@@ -35,6 +37,7 @@ summonai/
 ├── setup.sh                  # one-command setup
 ├── Makefile                  # make setup / make start
 ├── .claude/settings.json     # hooks config (git-tracked)
+├── .codex/hooks.json         # Codex SessionStart hook config (git-tracked)
 ├── .mcp.json                 # MCP server registration (git-ignored, machine-specific)
 ├── .summonai/memory.toml     # memory hook identity config (git-ignored)
 ├── config/
@@ -47,6 +50,9 @@ summonai/
 │   └── scripts/              # session hooks
 ├── task-mcp/                 # submodule: task orchestration server
 ├── scripts/
+│   ├── hooks/
+│   │   ├── session-start.sh  # shared SessionStart wrapper for Claude/Codex
+│   │   └── stop.sh           # shared Stop wrapper for Claude
 │   └── demo_task_agent.py    # demo task runner
 └── examples/
     └── hello-task.md         # sample task payload

--- a/scripts/hooks/session-start.sh
+++ b/scripts/hooks/session-start.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+export SUMMONAI_DIR="${SUMMONAI_DIR:-$ROOT_DIR}"
+export SUMMONAI_MEMORY_CONFIG="${SUMMONAI_MEMORY_CONFIG:-$ROOT_DIR/.summonai/memory.toml}"
+
+exec "$ROOT_DIR/memory-mcp/scripts/session_start_memory_context.sh"

--- a/scripts/hooks/stop.sh
+++ b/scripts/hooks/stop.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+export SUMMONAI_DIR="${SUMMONAI_DIR:-$ROOT_DIR}"
+export SUMMONAI_MEMORY_CONFIG="${SUMMONAI_MEMORY_CONFIG:-$ROOT_DIR/.summonai/memory.toml}"
+
+exec "$ROOT_DIR/memory-mcp/scripts/stop_hook_conversation_save.sh"

--- a/setup.sh
+++ b/setup.sh
@@ -92,7 +92,7 @@ else
   echo "Skipped (exists): $EXECUTORS_CONFIG"
 fi
 
-# ── 7. Hooks (SessionStart + Stop) ──
+# ── 7. Hooks (Claude: SessionStart + Stop, Codex: SessionStart) ──
 mkdir -p "$ROOT_DIR/.claude"
 if [ ! -f "$SETTINGS_PATH" ]; then
   printf '{}\n' > "$SETTINGS_PATH"
@@ -106,7 +106,7 @@ jq --arg root "$ROOT_DIR" '
         "hooks": [
           {
             "type": "command",
-            "command": ("SUMMONAI_DIR=" + $root + " SUMMONAI_MEMORY_CONFIG=" + $root + "/.summonai/memory.toml bash " + $root + "/memory-mcp/scripts/session_start_memory_context.sh"),
+            "command": ("SUMMONAI_DIR=" + $root + " SUMMONAI_MEMORY_CONFIG=" + $root + "/.summonai/memory.toml bash " + $root + "/scripts/hooks/session-start.sh"),
             "timeout": 15
           }
         ]
@@ -117,7 +117,7 @@ jq --arg root "$ROOT_DIR" '
         "hooks": [
           {
             "type": "command",
-            "command": ("SUMMONAI_DIR=" + $root + " SUMMONAI_MEMORY_CONFIG=" + $root + "/.summonai/memory.toml bash " + $root + "/memory-mcp/scripts/stop_hook_conversation_save.sh"),
+            "command": ("SUMMONAI_DIR=" + $root + " SUMMONAI_MEMORY_CONFIG=" + $root + "/.summonai/memory.toml bash " + $root + "/scripts/hooks/stop.sh"),
             "timeout": 15
           }
         ]
@@ -139,7 +139,8 @@ done
 echo ""
 echo "Setup complete."
 echo "- MCP servers: .mcp.json"
-echo "- Hooks: .claude/settings.json (SessionStart + Stop)"
+echo "- Hooks (Claude): .claude/settings.json (SessionStart + Stop)"
+echo "- Hooks (Codex): .codex/hooks.json (SessionStart)"
 echo "- Memory hook config: .summonai/memory.toml"
 echo "- Persona source: $PERSONA_DIR"
 echo "- Memory venv: memory-mcp/.venv"


### PR DESCRIPTION
## Summary
- add repository-level Codex SessionStart hook config at `.codex/hooks.json`
- add shared wrapper scripts at `scripts/hooks/session-start.sh` and `scripts/hooks/stop.sh`
- switch Claude hook setup in `setup.sh` to the shared wrappers so Claude/Codex bootstrap logic stays symmetric
- update `README.md` with Codex hook behavior and script layout

## Verification
- `jq . .codex/hooks.json` succeeds
- `bash -n setup.sh` succeeds
- dry-run session-start wrapper with simulated executor pane + hook payloads for startup/resume/clear confirms output includes:
  - `task_get(task_id=...)` protocol line
  - injected `instructions/executor.md` markers (`BEGIN/END`)

## Acceptance mapping (Task 050)
- SessionStart hook added in `.codex/hooks.json` with startup/resume (and clear) matcher
- `SUMMONAI_TASK_ID` resolution path verified via pane-id temp file mapping used by `session_start_memory_context.py`
- `instructions/executor.md` injection verified in wrapper dry-run output
- Claude/Codex startup path symmetry achieved by shared `scripts/hooks` wrappers
- bloom_level 1-3 executor startup flow checked via three dry-run cases (`task-bloom-1/2/3`)
