### PR TITLE
fix(task-mcp): worktree stderr propagation and resume recovery

### DIFF
--- a/task-mcp/src/summonai_task/server.py
+++ b/task-mcp/src/summonai_task/server.py
@@ -299,13 +299,17 @@ def _worktree_path(project_dir: str, task_id: str) -> Path:
 def _create_worktree(project_dir: str, task_id: str) -> Path:
     worktree = _worktree_path(project_dir, task_id)
     branch = f"feature/{task_id}"
-    subprocess.run(
-        ["git", "worktree", "add", str(worktree), "-b", branch, "origin/main"],
-        cwd=project_dir,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        subprocess.run(
+            ["git", "worktree", "add", str(worktree), "-b", branch, "origin/main"],
+            cwd=project_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        raise RuntimeError(f"git worktree add failed: {stderr}") from exc
     return worktree
 
 
@@ -1074,14 +1078,24 @@ def task_resume(task_id: str, actor_id: str = "system") -> dict:
                 "pane_id": current_pane_id,
             }
 
-        resume_cfg = _load_executors_config(config.get("project_dir"))
+        extra_env: dict[str, str] = {}
+        project_dir = config.get("project_dir")
+        if row["needs_worktree"] and project_dir:
+            worktree = _worktree_path(project_dir, task_id)
+            if not worktree.exists():
+                worktree = _create_worktree(project_dir, task_id)
+            extra_env["SUMMONAI_WORKTREE_PATH"] = str(worktree)
+
+        resume_cfg = _load_executors_config(project_dir)
         resume_bloom = int(row["bloom_level"] if row["bloom_level"] is not None else 3)
         resume_executor = row["executor"] or None
         resume_tier, resume_gap = _select_model_tier(resume_bloom, resume_executor, resume_cfg["capability_tiers"])
         resume_cmd = _build_executor_command(resume_tier, resume_cfg["runners"], resume_gap, resume_bloom)
 
         pane_id = _spawn_executor_pane(
-            session, task_id, _executor_resume_prompt(task_id), launch_command=resume_cmd
+            session, task_id, _executor_resume_prompt(task_id),
+            extra_env=extra_env or None,
+            launch_command=resume_cmd,
         )
         conn.execute("UPDATE tasks SET pane_id = ?, updated_at = ? WHERE id = ?", (pane_id, _utc_now(), task_id))
         _log_event(

--- a/task-mcp/tests/test_server.py
+++ b/task-mcp/tests/test_server.py
@@ -1678,6 +1678,183 @@ def test_task_complete_does_not_remove_worktree_when_flag_false(
     assert remove_calls == []
 
 
+def test_create_worktree_stderr_propagated_to_runner_error(
+    isolated_db: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config = tmp_path / "runner_config.json"
+    config.write_text(
+        json.dumps({
+            "enabled": True,
+            "runner": "zellij",
+            "zellij_session": "summonai",
+            "project_dir": str(tmp_path),
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SUMMONAI_TASK_RUNNER_CONFIG", str(config))
+    monkeypatch.setattr(server.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(server.pane, "list_panes", lambda _session: [])
+
+    import subprocess as _subprocess
+
+    original_run = _subprocess.run
+
+    def _failing_run(cmd: list[str], **kwargs):
+        if cmd[:2] == ["git", "worktree"]:
+            exc = _subprocess.CalledProcessError(1, cmd)
+            exc.stderr = "fatal: branch already exists"
+            raise exc
+        return original_run(cmd, **kwargs)
+
+    monkeypatch.setattr(server.subprocess, "run", _failing_run)
+
+    created = server.task_create(
+        title="Stderr test",
+        north_star="stderr propagation",
+        purpose="verify stderr in runner_error",
+        acceptance_criteria=["stderr in runner_error"],
+        project="summonai-task",
+        priority="high",
+        creator_role="interface",
+        assignee_role="executor",
+        needs_worktree=True,
+    )
+
+    assert created["runner_started"] is False
+    assert created["runner_error"] is not None
+    assert "fatal: branch already exists" in created["runner_error"]
+
+
+def test_task_resume_recreates_worktree_when_missing(
+    isolated_db: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config = tmp_path / "runner_config.json"
+    config.write_text(
+        json.dumps({
+            "enabled": True,
+            "runner": "zellij",
+            "zellij_session": "summonai",
+            "project_dir": str(tmp_path),
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SUMMONAI_TASK_RUNNER_CONFIG", str(config))
+    monkeypatch.setattr(server.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    created = server.task_create(
+        title="Resume worktree",
+        north_star="worktree recovery",
+        purpose="verify worktree recreation on resume",
+        acceptance_criteria=["worktree recreated"],
+        project="summonai-task",
+        priority="high",
+        creator_role="interface",
+        assignee_role="executor",
+        needs_worktree=True,
+    )
+    task_id = created["task_id"]
+
+    worktree_calls: list[tuple[str, str]] = []
+
+    def _fake_create_worktree(project_dir: str, tid: str) -> Path:
+        worktree_calls.append((project_dir, tid))
+        wt = Path(project_dir) / ".worktrees" / tid
+        wt.mkdir(parents=True, exist_ok=True)
+        return wt
+
+    monkeypatch.setattr(server, "_create_worktree", _fake_create_worktree)
+    monkeypatch.setattr(server.pane, "list_panes", lambda _session: [])
+    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name: "terminal_77")
+    monkeypatch.setattr(server.pane, "go_to_tab", lambda _session, _tab_name: None)
+
+    sent_payloads: list[str] = []
+    monkeypatch.setattr(
+        server.pane,
+        "send_text",
+        lambda _session, _pane_id, text: sent_payloads.append(text),
+    )
+    monkeypatch.setattr(
+        server,
+        "_wait_for_any_output",
+        lambda _session, _pane_id, timeout=30.0, interval=0.5: "executor >",
+    )
+
+    result = server.task_resume(task_id=task_id, actor_id="interface")
+
+    assert result["resumed"] is True
+    assert len(worktree_calls) == 1
+    assert worktree_calls[0][1] == task_id
+
+    worktree_path = str(Path(str(tmp_path)) / ".worktrees" / task_id)
+    launch_cmd = sent_payloads[0]
+    assert f"SUMMONAI_WORKTREE_PATH={worktree_path}" in launch_cmd
+
+
+def test_task_resume_skips_worktree_creation_when_exists(
+    isolated_db: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config = tmp_path / "runner_config.json"
+    config.write_text(
+        json.dumps({
+            "enabled": True,
+            "runner": "zellij",
+            "zellij_session": "summonai",
+            "project_dir": str(tmp_path),
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SUMMONAI_TASK_RUNNER_CONFIG", str(config))
+    monkeypatch.setattr(server.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    created = server.task_create(
+        title="Resume existing worktree",
+        north_star="worktree skip",
+        purpose="verify worktree not recreated when exists",
+        acceptance_criteria=["worktree not recreated"],
+        project="summonai-task",
+        priority="high",
+        creator_role="interface",
+        assignee_role="executor",
+        needs_worktree=True,
+    )
+    task_id = created["task_id"]
+
+    existing_worktree = tmp_path / ".worktrees" / task_id
+    existing_worktree.mkdir(parents=True, exist_ok=True)
+
+    worktree_calls: list[tuple[str, str]] = []
+
+    def _fake_create_worktree(project_dir: str, tid: str) -> Path:
+        worktree_calls.append((project_dir, tid))
+        return Path(project_dir) / ".worktrees" / tid
+
+    monkeypatch.setattr(server, "_create_worktree", _fake_create_worktree)
+    monkeypatch.setattr(server.pane, "list_panes", lambda _session: [])
+    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name: "terminal_78")
+    monkeypatch.setattr(server.pane, "go_to_tab", lambda _session, _tab_name: None)
+
+    sent_payloads: list[str] = []
+    monkeypatch.setattr(
+        server.pane,
+        "send_text",
+        lambda _session, _pane_id, text: sent_payloads.append(text),
+    )
+    monkeypatch.setattr(
+        server,
+        "_wait_for_any_output",
+        lambda _session, _pane_id, timeout=30.0, interval=0.5: "executor >",
+    )
+
+    result = server.task_resume(task_id=task_id, actor_id="interface")
+
+    assert result["resumed"] is True
+    assert worktree_calls == []
+
+    worktree_path = str(existing_worktree)
+    launch_cmd = sent_payloads[0]
+    assert f"SUMMONAI_WORKTREE_PATH={worktree_path}" in launch_cmd
+
+
 # ── _cleanup_panes_without_tasks tests ────────────────────────────────────────
 
 def test_cleanup_panes_without_tasks_closes_orphan_hex_pane(


### PR DESCRIPTION
## Summary
- `_create_worktree` の subprocess 失敗時、`CalledProcessError.stderr` を `RuntimeError` に含めて再送出。`runner_error` に実際の git エラーメッセージが入るようになった
- `task_resume` で `needs_worktree=true` かつ worktree が存在しない場合、自動で `_create_worktree` を呼び `SUMMONAI_WORKTREE_PATH` を設定するリカバリロジックを追加
- 新規テスト3件: stderr伝播、resume時worktree再作成、既存worktreeスキップ

## Test plan
- [x] 既存テスト101件全パス
- [x] `test_create_worktree_stderr_propagated_to_runner_error` — stderr が runner_error に含まれることを検証
- [x] `test_task_resume_recreates_worktree_when_missing` — resume時のworktree再作成を検証
- [x] `test_task_resume_skips_worktree_creation_when_exists` — 既存worktreeがある場合は再作成しないことを検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)