### PR TITLE
feat(task-mcp): expand _executor_start_prompt with workflow instructions

### DIFF
--- a/task-mcp/src/summonai_task/server.py
+++ b/task-mcp/src/summonai_task/server.py
@@ -272,7 +272,12 @@ def _active_pane_ids(session: str) -> set[str]:
 
 
 def _executor_start_prompt(task_id: str) -> str:
-    return f'start task_id="{task_id}"'
+    return (
+        f'start task_id="{task_id}" — '
+        f'task_get(task_id="{task_id}") で purpose/acceptance_criteria を確認し、'
+        f'task_update(status="in_progress") を呼んでから作業を開始せよ。'
+        f'完了後は task_complete を呼べ。'
+    )
 
 
 def _executor_resume_prompt(task_id: str) -> str:

--- a/task-mcp/tests/test_server.py
+++ b/task-mcp/tests/test_server.py
@@ -212,9 +212,10 @@ def test_task_create_starts_zellij_runner_and_persists_pane_id(
         (
             "summonai",
             "terminal_42",
-            f'task_id="{created["task_id"]}" のタスクを開始せよ。'
-            f'task_get(task_id="{created["task_id"]}") でタスク詳細を確認し、'
-            "acceptance_criteria を満たして task_complete を呼べ。",
+            f'start task_id="{created["task_id"]}" — '
+            f'task_get(task_id="{created["task_id"]}") で purpose/acceptance_criteria を確認し、'
+            f'task_update(status="in_progress") を呼んでから作業を開始せよ。'
+            f'完了後は task_complete を呼べ。',
         ),
     ]
     assert wait_calls == [30.0, 60.0]


### PR DESCRIPTION
## Summary

- `_executor_start_prompt()` に `task_get → task_update(in_progress) → 作業 → task_complete` のワークフロー指示を追加
- hook非対応のCodex executorが起動プロンプトだけで正しいワークフローを把握できるようにする
- プロンプトは4行に収め、executor.mdの丸ごと埋め込みは行わない

## Test plan

- [x] 119件の既存テストがすべてパスすることを確認
- [x] テスト内の期待プロンプト文字列を新しい形式に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)