### PR TITLE
feat(hooks): add Codex CLI SessionStart hook wrapper script

### DIFF
--- a/memory-mcp/scripts/session_start_memory_context_codex.sh
+++ b/memory-mcp/scripts/session_start_memory_context_codex.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Codex CLI SessionStart hook wrapper.
+# Runs session_start_memory_context.py and wraps the plain-text output in
+# the JSON format that the Codex hook engine expects (additionalContext).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Capture the plain-text output from the existing hook script.
+# Pass stdin (Codex JSON payload) through to the underlying script.
+context="$(cat - | bash "$SCRIPT_DIR/session_start_memory_context.sh")" || {
+  # If the underlying script fails, emit a minimal valid JSON so Codex
+  # does not mark the hook as failed.
+  printf '{"continue":true,"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"[session_start_memory_context] hook script returned non-zero exit code"}}'
+  exit 0
+}
+
+if [[ -z "$context" ]]; then
+  # Empty output: no context to inject, just continue.
+  printf '{"continue":true}'
+  exit 0
+fi
+
+# Escape the context string for JSON embedding.
+escaped="$(printf '%s' "$context" | python3 -c "
+import sys, json
+print(json.dumps(sys.stdin.read()), end='')
+")"
+
+printf '{"continue":true,"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}' "$escaped"


### PR DESCRIPTION
## Summary

- `session_start_memory_context_codex.sh` を新規作成
- 既存の `session_start_memory_context.py` の plain-text 出力を Codex CLI が期待する JSON 形式（`additionalContext`）でラップ
- `~/.codex/hooks.json` に SessionStart hook として登録済み（ユーザーレベル設定）

## 背景

Codex CLI の SessionStart hook は stdout が `[` で始まる場合に JSON として解析を試みるが、失敗すると hook failure とマークする。既存スクリプトの出力が `[SESSION_START_...]` プレフィックスを使っており、このため hook が常に失敗していた。

本PRのラッパーにより `hook: SessionStart Completed` を実機で確認済み。

## Test plan

- [x] `codex features enable codex_hooks` で `codex_hooks = true` を有効化済み
- [x] `~/.codex/hooks.json` に SessionStart hook を登録済み
- [x] `codex exec` コマンドで `hook: SessionStart Completed` を確認
- [x] モデルが executor.md 指示と memory_load 指示を受け取ることをモデル応答から確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)