### PR TITLE
fix: include task_id in executor start prompt update instruction

### DIFF
--- a/task-mcp/src/summonai_task/server.py
+++ b/task-mcp/src/summonai_task/server.py
@@ -273,10 +273,8 @@ def _active_pane_ids(session: str) -> set[str]:
 
 def _executor_start_prompt(task_id: str) -> str:
     return (
-        f'start task_id="{task_id}" — '
-        f'task_get(task_id="{task_id}") で purpose/acceptance_criteria を確認し、'
-        f'task_update(status="in_progress") を呼んでから作業を開始せよ。'
-        f'完了後は task_complete を呼べ。'
+        f'start task_id="{task_id}"。'
+        f'開始したら最初に task_update(task_id="{task_id}", status="in_progress") を呼べ。'
     )
 
 

--- a/task-mcp/tests/test_server.py
+++ b/task-mcp/tests/test_server.py
@@ -212,10 +212,8 @@ def test_task_create_starts_zellij_runner_and_persists_pane_id(
         (
             "summonai",
             "terminal_42",
-            f'start task_id="{created["task_id"]}" — '
-            f'task_get(task_id="{created["task_id"]}") で purpose/acceptance_criteria を確認し、'
-            f'task_update(status="in_progress") を呼んでから作業を開始せよ。'
-            f'完了後は task_complete を呼べ。',
+            f'start task_id="{created["task_id"]}"。'
+            f'開始したら最初に task_update(task_id="{created["task_id"]}", status="in_progress") を呼べ。',
         ),
     ]
     assert wait_calls == [30.0, 60.0]


### PR DESCRIPTION
## Summary
- update `_executor_start_prompt()` to instruct `task_update(task_id=..., status="in_progress")`
- align `test_task_create_starts_zellij_runner_and_persists_pane_id` expected prompt text

## Test
- `pytest -q tests/test_server.py`
