### PR TITLE
fix(pane): pass --cwd to zellij new-tab so executor starts in project root

### DIFF
--- a/task-mcp/src/summonai_task/pane.py
+++ b/task-mcp/src/summonai_task/pane.py
@@ -56,14 +56,20 @@ def _normalize_pane_id(value: object, pane: dict) -> str:
     return raw
 
 
-def create_tab(session: str, name: str) -> str:
+def create_tab(session: str, name: str, cwd: str | None = None) -> str:
     """Create a new tab and return its default pane_id.
 
     Issues ``zellij action new-tab --name <name>`` and returns the pane_id of
     the single default pane that zellij creates inside the new tab.
+
+    When *cwd* is given, ``--cwd <path>`` is passed so the new tab's shell
+    starts in the specified directory instead of inheriting the server's cwd.
     """
     before = {pane_id for pane_id in (_extract_pane_id(p) for p in list_panes(session)) if pane_id}
-    _run_zellij(session, ["new-tab", "--name", name])
+    cmd = ["new-tab", "--name", name]
+    if cwd is not None:
+        cmd.extend(["--cwd", cwd])
+    _run_zellij(session, cmd)
     after = list_panes(session)
     new_ids = [pane_id for pane_id in (_extract_pane_id(p) for p in after) if pane_id and pane_id not in before]
     if len(new_ids) == 1:

--- a/task-mcp/src/summonai_task/server.py
+++ b/task-mcp/src/summonai_task/server.py
@@ -331,10 +331,11 @@ def _spawn_executor_pane(
     prompt: str,
     extra_env: dict[str, str] | None = None,
     launch_command: str = "claude --dangerously-skip-permissions",
+    cwd: str | None = None,
 ) -> str:
     pane_id: str | None = None
     try:
-        pane_id = pane.create_tab(session, f"task-{task_id}")
+        pane_id = pane.create_tab(session, f"task-{task_id}", cwd=cwd)
         # Restore focus to the interface tab so it is not displaced by the new
         # executor tab.  Best-effort: if the tab does not exist yet (e.g. old
         # layout without tab name), skip rather than aborting the spawn.
@@ -402,9 +403,11 @@ def _spawn_task_runner_if_configured(conn: sqlite3.Connection, task_id: str) -> 
     task_row = _get_task_row(conn, task_id)
     extra_env: dict[str, str] = {}
     project_dir = config["project_dir"]
+    executor_cwd = project_dir
     if task_row["needs_worktree"] and project_dir:
         worktree = _create_worktree(project_dir, task_id)
         extra_env["SUMMONAI_WORKTREE_PATH"] = str(worktree)
+        executor_cwd = str(worktree)
 
     executors_cfg = _load_executors_config(project_dir)
     tiers = executors_cfg["capability_tiers"]
@@ -418,6 +421,7 @@ def _spawn_task_runner_if_configured(conn: sqlite3.Connection, task_id: str) -> 
         session, task_id, _executor_start_prompt(task_id),
         extra_env=extra_env or None,
         launch_command=launch_command,
+        cwd=executor_cwd,
     )
 
     conn.execute("UPDATE tasks SET pane_id = ?, updated_at = ? WHERE id = ?", (pane_id, _utc_now(), task_id))
@@ -1079,11 +1083,13 @@ def task_resume(task_id: str, actor_id: str = "system") -> dict:
 
         extra_env: dict[str, str] = {}
         project_dir = config.get("project_dir")
+        executor_cwd = project_dir
         if row["needs_worktree"] and project_dir:
             worktree = _worktree_path(project_dir, task_id)
             if not worktree.exists():
                 worktree = _create_worktree(project_dir, task_id)
             extra_env["SUMMONAI_WORKTREE_PATH"] = str(worktree)
+            executor_cwd = str(worktree)
 
         resume_cfg = _load_executors_config(project_dir)
         resume_bloom = int(row["bloom_level"] if row["bloom_level"] is not None else 3)
@@ -1095,6 +1101,7 @@ def task_resume(task_id: str, actor_id: str = "system") -> dict:
             session, task_id, _executor_resume_prompt(task_id),
             extra_env=extra_env or None,
             launch_command=resume_cmd,
+            cwd=executor_cwd,
         )
         conn.execute("UPDATE tasks SET pane_id = ?, updated_at = ? WHERE id = ?", (pane_id, _utc_now(), task_id))
         _log_event(
@@ -1185,11 +1192,18 @@ def task_reopen(task_id: str, message: str, actor_id: str = "system") -> dict:
         runner_error: str | None = None
         result_pane_id = existing_pane_id
 
-        executors_cfg = _load_executors_config(config.get("project_dir"))
+        reopen_project_dir = config.get("project_dir")
+        executors_cfg = _load_executors_config(reopen_project_dir)
         reopen_bloom = int(row["bloom_level"] if row["bloom_level"] is not None else 3)
         reopen_executor = row["executor"] or None
         reopen_tier, reopen_gap = _select_model_tier(reopen_bloom, reopen_executor, executors_cfg["capability_tiers"])
         reopen_cmd = _build_executor_command(reopen_tier, executors_cfg["runners"], reopen_gap, reopen_bloom)
+
+        reopen_cwd = reopen_project_dir
+        if row["needs_worktree"] and reopen_project_dir:
+            wt = _worktree_path(reopen_project_dir, task_id)
+            if wt.exists():
+                reopen_cwd = str(wt)
 
         if config["enabled"]:
             if not session:
@@ -1211,7 +1225,7 @@ def task_reopen(task_id: str, message: str, actor_id: str = "system") -> dict:
             else:
                 new_pane_id: str | None = None
                 try:
-                    new_pane_id = pane.create_tab(session, f"task-{task_id}")
+                    new_pane_id = pane.create_tab(session, f"task-{task_id}", cwd=reopen_cwd)
                     pane.go_to_tab(session, INTERFACE_TAB_NAME)
                     task_id_file = Path(tempfile.gettempdir()) / f"summonai_pane_{new_pane_id}.task_id"
                     task_id_file.write_text(task_id, encoding="utf-8")

--- a/task-mcp/tests/test_pane.py
+++ b/task-mcp/tests/test_pane.py
@@ -103,6 +103,40 @@ def test_create_tab_returns_new_pane_id() -> None:
         ]
 
 
+def test_create_tab_with_cwd_passes_cwd_flag() -> None:
+    with patch(
+        "summonai_task.pane.subprocess.run",
+        side_effect=[
+            _cp(stdout='[{"id":1}]'),
+            _cp(),
+            _cp(stdout='[{"id":1},{"id":2}]'),
+        ],
+    ) as run:
+        pane_id = pane.create_tab("summonai", "task-002", cwd="/home/user/project")
+
+        assert pane_id == "terminal_2"
+        assert run.call_args_list == [
+            call(
+                ["zellij", "--session", "summonai", "action", "list-panes", "--json"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ),
+            call(
+                ["zellij", "--session", "summonai", "action", "new-tab", "--name", "task-002", "--cwd", "/home/user/project"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ),
+            call(
+                ["zellij", "--session", "summonai", "action", "list-panes", "--json"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ),
+        ]
+
+
 def test_send_text_writes_payload_and_enter() -> None:
     with (
         patch("summonai_task.pane.subprocess.run", return_value=_cp()) as run,

--- a/task-mcp/tests/test_server.py
+++ b/task-mcp/tests/test_server.py
@@ -172,7 +172,7 @@ def test_task_create_starts_zellij_runner_and_persists_pane_id(
 
     sent_payloads: list[tuple[str, str, str]] = []
     monkeypatch.setattr(server.pane, "list_panes", lambda _session: [])
-    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name: "terminal_42")
+    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name, cwd=None: "terminal_42")
     monkeypatch.setattr(server.pane, "go_to_tab", lambda _session, _tab_name: None)
     monkeypatch.setattr(
         server.pane,
@@ -271,7 +271,7 @@ def test_task_create_returns_runner_error_on_ready_timeout(
     )
     monkeypatch.setenv("SUMMONAI_TASK_RUNNER_CONFIG", str(config))
     monkeypatch.setattr(server.pane, "list_panes", lambda _session: [])
-    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name: "42")
+    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name, cwd=None: "42")
     monkeypatch.setattr(server.pane, "go_to_tab", lambda _session, _tab_name: None)
     monkeypatch.setattr(server.pane, "send_text", lambda _session, _pane_id, _text: None)
     closed: list[str] = []
@@ -308,7 +308,7 @@ def test_task_create_returns_runner_error_when_executor_prompt_timeout(
     )
     monkeypatch.setenv("SUMMONAI_TASK_RUNNER_CONFIG", str(config))
     monkeypatch.setattr(server.pane, "list_panes", lambda _session: [])
-    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name: "42")
+    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name, cwd=None: "42")
     monkeypatch.setattr(server.pane, "go_to_tab", lambda _session, _tab_name: None)
     sent_payloads: list[str] = []
     monkeypatch.setattr(server.pane, "send_text", lambda _session, _pane_id, text: sent_payloads.append(text))
@@ -636,7 +636,7 @@ def test_task_resume_recreates_missing_pane(
         conn.execute("UPDATE tasks SET status = ?, pane_id = ? WHERE id = ?", ("assigned", "terminal_10", task_id))
 
     monkeypatch.setattr(server.pane, "list_panes", lambda _session: [{"pane_id": "terminal_99"}])
-    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name: "terminal_42")
+    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name, cwd=None: "terminal_42")
     monkeypatch.setattr(server.pane, "go_to_tab", lambda _session, _tab_name: None)
     sent_payloads: list[tuple[str, str, str]] = []
     monkeypatch.setattr(
@@ -1364,7 +1364,7 @@ def test_task_reopen_without_pane_creates_new_pane(
 
     sent_payloads: list[tuple[str, str, str]] = []
     monkeypatch.setattr(server.pane, "list_panes", lambda _session: [])
-    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name: "terminal_77")
+    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name, cwd=None: "terminal_77")
     monkeypatch.setattr(server.pane, "go_to_tab", lambda _session, _tab_name: None)
     monkeypatch.setattr(
         server.pane, "send_text",
@@ -1469,7 +1469,7 @@ def test_spawn_creates_worktree_when_needs_worktree_true(
 
     monkeypatch.setattr(server, "_create_worktree", _fake_create_worktree)
     monkeypatch.setattr(server.pane, "list_panes", lambda _session: [])
-    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name: "terminal_99")
+    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name, cwd=None: "terminal_99")
     monkeypatch.setattr(server.pane, "go_to_tab", lambda _session, _tab_name: None)
 
     sent_payloads: list[str] = []
@@ -1530,7 +1530,7 @@ def test_spawn_does_not_create_worktree_when_needs_worktree_false(
 
     monkeypatch.setattr(server, "_create_worktree", _fake_create_worktree)
     monkeypatch.setattr(server.pane, "list_panes", lambda _session: [])
-    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name: "terminal_88")
+    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name, cwd=None: "terminal_88")
     monkeypatch.setattr(server.pane, "go_to_tab", lambda _session, _tab_name: None)
     monkeypatch.setattr(server.pane, "send_text", lambda *a, **kw: None)
     monkeypatch.setattr(
@@ -1763,7 +1763,7 @@ def test_task_resume_recreates_worktree_when_missing(
 
     monkeypatch.setattr(server, "_create_worktree", _fake_create_worktree)
     monkeypatch.setattr(server.pane, "list_panes", lambda _session: [])
-    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name: "terminal_77")
+    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name, cwd=None: "terminal_77")
     monkeypatch.setattr(server.pane, "go_to_tab", lambda _session, _tab_name: None)
 
     sent_payloads: list[str] = []
@@ -1829,7 +1829,7 @@ def test_task_resume_skips_worktree_creation_when_exists(
 
     monkeypatch.setattr(server, "_create_worktree", _fake_create_worktree)
     monkeypatch.setattr(server.pane, "list_panes", lambda _session: [])
-    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name: "terminal_78")
+    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name, cwd=None: "terminal_78")
     monkeypatch.setattr(server.pane, "go_to_tab", lambda _session, _tab_name: None)
 
     sent_payloads: list[str] = []
@@ -2258,7 +2258,7 @@ template = "claude --model {model} --dangerously-skip-permissions"
     monkeypatch.delenv("SUMMONAI_EXECUTORS_CONFIG", raising=False)
     monkeypatch.setattr(server.tempfile, "gettempdir", lambda: str(tmp_path))
     monkeypatch.setattr(server.pane, "list_panes", lambda _session: [])
-    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name: "terminal_42")
+    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name, cwd=None: "terminal_42")
     monkeypatch.setattr(server.pane, "go_to_tab", lambda _session, _tab_name: None)
 
     sent_payloads: list[str] = []
@@ -2318,7 +2318,7 @@ template = "claude --model {model} --dangerously-skip-permissions"
     monkeypatch.delenv("SUMMONAI_EXECUTORS_CONFIG", raising=False)
     monkeypatch.setattr(server.tempfile, "gettempdir", lambda: str(tmp_path))
     monkeypatch.setattr(server.pane, "list_panes", lambda _session: [])
-    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name: "terminal_42")
+    monkeypatch.setattr(server.pane, "create_tab", lambda _session, name, cwd=None: "terminal_42")
     monkeypatch.setattr(server.pane, "go_to_tab", lambda _session, _tab_name: None)
 
     sent_payloads: list[str] = []


### PR DESCRIPTION
## Summary
- executor pane が task-mcp サーバーの cwd を継承してしまい、成果物が誤った場所に配置されるバグを修正
- `pane.create_tab()` に `cwd` パラメータを追加し、zellij new-tab に `--cwd` を渡すようにした
- `_spawn_executor_pane()`, `_spawn_task_runner_if_configured()`, `task_resume()`, `task_reopen()` の4箇所で project_dir / worktree パスを伝播

## Test plan
- [x] 既存テスト120件パス
- [x] `test_create_tab_with_cwd_passes_cwd_flag` 追加済
- [x] cwd=None 時の後方互換性を維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)