### PR TITLE
fix(pane): use send-keys Enter instead of raw write 13

### DIFF
--- a/task-mcp/src/summonai_task/pane.py
+++ b/task-mcp/src/summonai_task/pane.py
@@ -145,8 +145,8 @@ def send_text(session: str, pane_id: str, text: str) -> None:
 
 
 def send_enter(session: str, pane_id: str) -> None:
-    """Send Enter key via carriage-return keycode."""
-    _run_zellij(session, ["write", "13", "--pane-id", pane_id])
+    """Send Enter key event to a pane."""
+    _run_zellij(session, ["send-keys", "--pane-id", pane_id, "Enter"])
 
 
 def read_output(session: str, pane_id: str, lines: int = 100) -> str:

--- a/task-mcp/tests/test_pane.py
+++ b/task-mcp/tests/test_pane.py
@@ -152,7 +152,7 @@ def test_send_text_writes_payload_and_enter() -> None:
                 check=True,
             ),
             call(
-                ["zellij", "--session", "summonai", "action", "write", "13", "--pane-id", "2"],
+                ["zellij", "--session", "summonai", "action", "send-keys", "--pane-id", "2", "Enter"],
                 capture_output=True,
                 text=True,
                 check=True,


### PR DESCRIPTION
## Summary
- Codex CLI (ink-based TUI) interprets `zellij action write 13` (raw CR byte) as a newline character in the input field, not as a submission trigger
- Changed `send_enter()` to use `zellij action send-keys Enter` which sends a proper key event
- Both Claude Code and Codex CLI handle `send-keys Enter` correctly

## Root cause
- `write <byte>` sends raw bytes to the terminal pty — TUI frameworks may interpret these as character input
- `send-keys <key>` sends a keyboard event — TUI frameworks recognize this as an actual keypress

## Test plan
- [x] Verified `send-keys Enter` submits prompt in Codex CLI (stuck prompt was unstuck)
- [x] `test_pane.py` updated and passing (19/19)
- [x] Manual testing: Codex CLI with `--no-alt-screen` accepts and processes prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)