### PR TITLE
Fix Passive Recall review issues (P1/P2)

### DIFF
--- a/memory-mcp/recall_socket.py
+++ b/memory-mcp/recall_socket.py
@@ -1,0 +1,24 @@
+"""Shared naming for passive recall Unix sockets."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+def _normalize_db_path(db_path: str) -> str:
+    return str(Path(db_path).expanduser().resolve())
+
+
+def db_scope_hash(db_path: str) -> str:
+    """Return a stable short hash for the realpath of the DB file."""
+    normalized = _normalize_db_path(db_path)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:12]
+
+
+def socket_filename(db_path: str, pid: int) -> str:
+    return f"summonai_recall_{db_scope_hash(db_path)}_{pid}.sock"
+
+
+def socket_glob(db_path: str) -> str:
+    return f"summonai_recall_{db_scope_hash(db_path)}_*.sock"

--- a/memory-mcp/recall_socket.py
+++ b/memory-mcp/recall_socket.py
@@ -7,7 +7,13 @@ from pathlib import Path
 
 
 def _normalize_db_path(db_path: str) -> str:
-    return str(Path(db_path).expanduser().resolve())
+    expanded = Path(db_path).expanduser()
+    if not expanded.is_absolute():
+        raise ValueError(f"SUMMONAI_MEMORY_DB must be an absolute path: {db_path}")
+    normalized = expanded.resolve()
+    if not normalized.is_absolute():
+        raise ValueError(f"Failed to normalize SUMMONAI_MEMORY_DB as absolute path: {db_path}")
+    return str(normalized)
 
 
 def db_scope_hash(db_path: str) -> str:

--- a/memory-mcp/scripts/passive_recall_hook.py
+++ b/memory-mcp/scripts/passive_recall_hook.py
@@ -16,13 +16,23 @@ import tempfile
 import time
 from pathlib import Path
 
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from recall_socket import socket_glob
+
 WINDOW_SIZE = 5       # sliding window: last N turns for dedup
 TOP_K = 3             # max memories to inject
 TOKEN_BUDGET = 500    # max total tokens
 SIM_THRESHOLD = 0.65  # keep in sync with server.py _RECALL_SIM_THRESHOLD
 
-SOCKET_GLOB = "summonai_recall_*.sock"
 SOCKET_TIMEOUT = 2.0  # seconds per socket attempt
+
+
+def _memory_db_path() -> str:
+    default_db = ROOT_DIR / "db" / "summonai_memory.db"
+    return os.environ.get("SUMMONAI_MEMORY_DB", str(default_db))
 
 
 def _estimate_tokens(text: str) -> int:
@@ -68,7 +78,7 @@ def _cleanup_stale_state_files() -> None:
 def _find_sockets() -> list[Path]:
     """Return socket files sorted by mtime descending (most recently active first)."""
     tmpdir = Path(tempfile.gettempdir())
-    socks = list(tmpdir.glob(SOCKET_GLOB))
+    socks = list(tmpdir.glob(socket_glob(_memory_db_path())))
     socks.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0, reverse=True)
     return socks
 
@@ -111,10 +121,6 @@ def _query_server(prompt_text: str) -> list[tuple[int, str, float]]:
 def recall(prompt_text: str, session_id: str) -> list[tuple[int, str, float]]:
     """Return dedup-filtered list of (memory_id, content, similarity) for injection."""
     raw = _query_server(prompt_text)
-    if not raw:
-        return []
-
-    # Apply dedup
     state_file = _state_path(session_id)
     if state_file and state_file.exists():
         state = _load_state(state_file)
@@ -134,11 +140,11 @@ def recall(prompt_text: str, session_id: str) -> list[tuple[int, str, float]]:
     for memory_id, content, similarity in candidates[:TOP_K]:
         tokens = _estimate_tokens(content)
         if total_tokens + tokens > TOKEN_BUDGET:
-            break
+            continue
         results.append((memory_id, content, similarity))
         total_tokens += tokens
 
-    if results and state_file is not None:
+    if state_file is not None:
         this_turn_ids = [mid for mid, _, _ in results]
         recent = state.get("recent_ids", [])
         if not isinstance(recent, list):

--- a/memory-mcp/server.py
+++ b/memory-mcp/server.py
@@ -34,6 +34,7 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 from hook_context import resolve_agent_id, resolve_scope  # noqa: E402
+from recall_socket import socket_filename  # noqa: E402
 
 # Database path: env var or default
 DEFAULT_DB_PATH = os.environ.get(
@@ -1657,11 +1658,12 @@ def conversation_load_recent(
 # Passive Recall Socket Server
 # ============================================================
 
-_RECALL_SOCKET_PATH = Path(tempfile.gettempdir()) / f"summonai_recall_{os.getpid()}.sock"
+_RECALL_SOCKET_PATH = Path(tempfile.gettempdir()) / socket_filename(_get_db_path(), os.getpid())
 _RECALL_SIM_THRESHOLD = 0.65
 _RECALL_TOP_K = 3
 _RECALL_TOKEN_BUDGET = 500
 _RECALL_SEARCH_K = 8
+_RECALL_CONN_TIMEOUT = 2.0
 
 
 def _recall_search(prompt_text: str) -> list[tuple[int, str, float]]:
@@ -1715,7 +1717,7 @@ def _recall_search(prompt_text: str) -> list[tuple[int, str, float]]:
             content = row["content"]
             tokens = len(content) // 4
             if total_tokens + tokens > _RECALL_TOKEN_BUDGET:
-                break
+                continue
             results.append((memory_id, content, similarity))
             total_tokens += tokens
         return results
@@ -1726,6 +1728,7 @@ def _recall_search(prompt_text: str) -> list[tuple[int, str, float]]:
 def _handle_recall_connection(conn_sock: socket.socket) -> None:
     """Handle one recall request over a Unix socket connection."""
     try:
+        conn_sock.settimeout(_RECALL_CONN_TIMEOUT)
         buf = b""
         while b"\n" not in buf:
             chunk = conn_sock.recv(4096)
@@ -1774,7 +1777,7 @@ def _recall_socket_server_loop() -> None:
                     )
                     t.start()
                 except Exception:
-                    break
+                    continue
     except Exception:
         pass
 

--- a/memory-mcp/tests/test_passive_recall_hook.py
+++ b/memory-mcp/tests/test_passive_recall_hook.py
@@ -67,6 +67,10 @@ class TestHelpers(unittest.TestCase):
                     self.assertEqual(socket_glob(db_path), f"summonai_recall_{expected_hash}_*.sock")
                     self.assertEqual(hook._find_sockets(), [matching])
 
+    def test_db_scope_hash_rejects_relative_path(self):
+        with self.assertRaises(ValueError):
+            db_scope_hash("relative/path/to/summonai_memory.db")
+
 
 # ---------------------------------------------------------------------------
 # Unit tests: state file

--- a/memory-mcp/tests/test_passive_recall_hook.py
+++ b/memory-mcp/tests/test_passive_recall_hook.py
@@ -23,10 +23,13 @@ from unittest import mock
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 import passive_recall_hook as hook
+from recall_socket import db_scope_hash, socket_glob
 
 
 # ---------------------------------------------------------------------------
@@ -50,6 +53,19 @@ class TestHelpers(unittest.TestCase):
     def test_state_path_unknown_returns_none(self):
         self.assertIsNone(hook._state_path(""))
         self.assertIsNone(hook._state_path("unknown"))
+
+    def test_socket_glob_uses_db_scope_hash(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = "/tmp/project-a/summonai_memory.db"
+            expected_hash = db_scope_hash(db_path)
+            matching = Path(tmpdir) / f"summonai_recall_{expected_hash}_100.sock"
+            other = Path(tmpdir) / "summonai_recall_deadbeef0000_101.sock"
+            matching.touch()
+            other.touch()
+            with mock.patch.dict("os.environ", {"SUMMONAI_MEMORY_DB": db_path}, clear=False):
+                with mock.patch("tempfile.gettempdir", return_value=tmpdir):
+                    self.assertEqual(socket_glob(db_path), f"summonai_recall_{expected_hash}_*.sock")
+                    self.assertEqual(hook._find_sockets(), [matching])
 
 
 # ---------------------------------------------------------------------------
@@ -195,11 +211,18 @@ class TestRecallDedup(unittest.TestCase):
         long_content = "x" * 2001  # 500 tokens
         with mock.patch.object(
             hook, "_query_server", return_value=[(1, long_content, 0.9), (2, "short", 0.8)]
-        ):
+        ), mock.patch.object(hook, "_state_path", return_value=None):
             results = hook.recall("query", "budget_session")
-        # First entry alone exceeds budget, so only it (or nothing if it busts) is returned
         total = sum(hook._estimate_tokens(c) for _, c, _ in results)
         self.assertLessEqual(total, hook.TOKEN_BUDGET)
+
+    def test_token_budget_skips_long_candidate_and_keeps_later_short_one(self):
+        too_long = "x" * 2101  # 525 tokens
+        with mock.patch.object(
+            hook, "_query_server", return_value=[(1, too_long, 0.9), (2, "short", 0.8)]
+        ), mock.patch.object(hook, "_state_path", return_value=None):
+            results = hook.recall("query", "budget_skip_session")
+        self.assertEqual([r[0] for r in results], [2])
 
     def test_sliding_window_persists(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -215,6 +238,20 @@ class TestRecallDedup(unittest.TestCase):
             real_state_file = Path(tmpdir) / state_file.name
             state = hook._load_state(real_state_file)
             self.assertIn([99], state["recent_ids"])
+
+    def test_sliding_window_advances_with_empty_turn(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_id = "empty_turn_session"
+            state_file = Path(tmpdir) / f"summonai_passive_recall_{session_id}.json"
+            hook._save_state(state_file, {"recent_ids": [[7], [8], [9], [10], [11]]})
+
+            with mock.patch("tempfile.gettempdir", return_value=tmpdir):
+                with mock.patch.object(hook, "_query_server", return_value=[]):
+                    results = hook.recall("query", session_id)
+            self.assertEqual(results, [])
+
+            updated = hook._load_state(state_file)
+            self.assertEqual(updated["recent_ids"], [[8], [9], [10], [11], []])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary\n- add DB realpath hash based socket naming for passive recall and shared helper module\n- scope hook socket discovery to the same DB hash\n- advance dedup sliding window even on empty recall turns\n- add recv timeout in recall socket request handler\n- keep accept loop alive on per-request errors\n- skip over budget candidates (continue) to allow later short candidates\n- add/adjust passive recall tests for hash scoping, empty-turn window advance, and token-budget skip behavior\n\n## Verification\n- 
[LATENCY mock-socket] p50=0.1ms  p95=0.3ms\n\n## Note\n- 既存 MCP サーバーの再起動が必要です。