### PR TITLE
Apply TRI scoring to passive recall ranking

### DIFF
--- a/memory-mcp/server.py
+++ b/memory-mcp/server.py
@@ -1662,7 +1662,7 @@ _RECALL_SOCKET_PATH = Path(tempfile.gettempdir()) / socket_filename(_get_db_path
 _RECALL_SIM_THRESHOLD = 0.65
 _RECALL_TOP_K = 3
 _RECALL_TOKEN_BUDGET = 500
-_RECALL_SEARCH_K = 8
+_RECALL_SEARCH_K = 20
 _RECALL_CONN_TIMEOUT = 2.0
 
 
@@ -1672,6 +1672,7 @@ def _recall_search(prompt_text: str) -> list[tuple[int, str, float]]:
     try:
         emb = _embed_model.encode(prompt_text)
         emb_norm = emb / np.linalg.norm(emb)
+        now = datetime.now(timezone.utc)
 
         # KNN by L2 distance to get candidate IDs (vec0 default metric)
         rows = conn.execute(
@@ -1687,7 +1688,7 @@ def _recall_search(prompt_text: str) -> list[tuple[int, str, float]]:
         ).fetchall()
 
         # Compute cosine similarity manually (stored vecs are not normalized)
-        candidates: list[tuple[int, float]] = []
+        candidates: list[tuple[int, float, float]] = []
         for r in rows:
             mid = int(r["memory_id"])
             vec_row = conn.execute(
@@ -1701,14 +1702,33 @@ def _recall_search(prompt_text: str) -> list[tuple[int, str, float]]:
                 continue
             sim = float(np.dot(emb_norm, stored / stored_n))
             if sim > _RECALL_SIM_THRESHOLD:
-                candidates.append((mid, sim))
+                memory_row = conn.execute(
+                    """
+                    SELECT content, importance, confidence, access_count, recall_count,
+                           emotional_impact, last_accessed_at, created_at
+                    FROM memories
+                    WHERE id = ?
+                    """,
+                    (mid,),
+                ).fetchone()
+                if not memory_row:
+                    continue
+                ranked_score = _memory_ranked_score(memory_row)
+                temporal_score = _memory_recency_score(
+                    memory_row["last_accessed_at"],
+                    memory_row["created_at"],
+                    now,
+                )
+                impact_score = _memory_impact_score(memory_row)
+                rank_multiplier = 1 + 0.30 * ranked_score + 0.18 * temporal_score + 0.12 * impact_score
+                candidates.append((mid, sim, sim * rank_multiplier))
 
-        candidates.sort(key=lambda x: x[1], reverse=True)
+        candidates.sort(key=lambda x: x[2], reverse=True)
         candidates = candidates[:_RECALL_TOP_K]
 
         results: list[tuple[int, str, float]] = []
         total_tokens = 0
-        for memory_id, similarity in candidates:
+        for memory_id, similarity, _ in candidates:
             row = conn.execute(
                 "SELECT content FROM memories WHERE id = ?", (memory_id,)
             ).fetchone()

--- a/memory-mcp/tests/test_conversation_memory.py
+++ b/memory-mcp/tests/test_conversation_memory.py
@@ -881,6 +881,112 @@ assistant: old chunk must disappear
         self.assertIsNotNone(stored)
         self.assertEqual(stored[0], multiline)
 
+    def test_recall_search_tri_rerank_changes_order(self):
+        prompt_vec = self.server.np.array([1.0, 0.0], dtype=self.server.np.float32)
+
+        def _vec(x: float, y: float) -> bytes:
+            return self.server.np.array([x, y], dtype=self.server.np.float32).tobytes()
+
+        embeddings = {
+            1: _vec(0.92, 0.39191836),   # A: high sim + fresh + high rank
+            2: _vec(0.95, 0.31224990),   # B: high sim + stale + low rank
+            3: _vec(0.80, 0.60000000),   # C: mid sim + fresh + high rank
+            4: _vec(0.82, 0.57236352),   # D: mid sim + stale + low rank
+        }
+
+        now = datetime.now()
+        fresh = now.isoformat(timespec="seconds")
+        stale = (now - timedelta(days=365)).isoformat(timespec="seconds")
+
+        memory_rows = {
+            1: {
+                "content": "A",
+                "importance": 9,
+                "confidence": 0.95,
+                "access_count": 10,
+                "recall_count": 10,
+                "emotional_impact": 9.0,
+                "last_accessed_at": fresh,
+                "created_at": fresh,
+            },
+            2: {
+                "content": "B",
+                "importance": 2,
+                "confidence": 0.30,
+                "access_count": 0,
+                "recall_count": 0,
+                "emotional_impact": 0.0,
+                "last_accessed_at": stale,
+                "created_at": stale,
+            },
+            3: {
+                "content": "C",
+                "importance": 9,
+                "confidence": 0.95,
+                "access_count": 10,
+                "recall_count": 10,
+                "emotional_impact": 9.0,
+                "last_accessed_at": fresh,
+                "created_at": fresh,
+            },
+            4: {
+                "content": "D",
+                "importance": 2,
+                "confidence": 0.30,
+                "access_count": 0,
+                "recall_count": 0,
+                "emotional_impact": 0.0,
+                "last_accessed_at": stale,
+                "created_at": stale,
+            },
+        }
+
+        class _FakeCursor:
+            def __init__(self, rows):
+                self._rows = rows
+
+            def fetchall(self):
+                return self._rows
+
+            def fetchone(self):
+                return self._rows[0] if self._rows else None
+
+        class _FakeConn:
+            def execute(self, sql, params=()):
+                if "FROM memories_vec mv" in sql:
+                    return _FakeCursor([{"memory_id": 1}, {"memory_id": 2}, {"memory_id": 3}, {"memory_id": 4}])
+                if "SELECT embedding FROM memories_vec" in sql:
+                    memory_id = int(params[0])
+                    return _FakeCursor([{"embedding": embeddings[memory_id]}])
+                if "SELECT content, importance, confidence, access_count, recall_count" in sql:
+                    memory_id = int(params[0])
+                    return _FakeCursor([memory_rows[memory_id]])
+                if "SELECT content FROM memories" in sql:
+                    memory_id = int(params[0])
+                    return _FakeCursor([{"content": memory_rows[memory_id]["content"]}])
+                raise AssertionError(f"unexpected query: {sql}")
+
+            def close(self):
+                return None
+
+        with mock.patch.object(self.server, "get_db", return_value=_FakeConn()), \
+             mock.patch.object(self.server, "_embed_model") as mock_model, \
+             mock.patch.object(self.server, "_RECALL_TOP_K", 4), \
+             mock.patch.object(self.server, "_RECALL_TOKEN_BUDGET", 10_000):
+            mock_model.encode.return_value = prompt_vec
+            results = self.server._recall_search("tri recall ranking")
+
+        tri_order = [memory_id for memory_id, _, _ in results]
+        self.assertEqual(tri_order, [1, 3, 2, 4])
+
+        similarity_only_order = sorted(
+            [1, 2, 3, 4],
+            key=lambda mid: float(self.server.np.dot(prompt_vec, self.server.np.frombuffer(embeddings[mid], dtype=self.server.np.float32))),
+            reverse=True,
+        )
+        self.assertEqual(similarity_only_order, [2, 1, 4, 3])
+        self.assertNotEqual(tri_order, similarity_only_order)
+
     def test_memory_load_returns_min_fields_and_normalizes_newlines_in_response_only(self):
         multiline = "load line1\nload line2"
         self.server.memory_save(

--- a/memory-mcp/tests/test_session_start_memory_context.py
+++ b/memory-mcp/tests/test_session_start_memory_context.py
@@ -29,10 +29,10 @@ class SessionStartMemoryContextTest(unittest.TestCase):
         with mock.patch.dict("os.environ", env, clear=True):
             self.assertEqual(session_start_memory_context.resolve_agent_id(payload), "coordinator")
 
-    def test_resolve_agent_id_defaults_to_default_outside_tmux(self):
+    def test_resolve_agent_id_defaults_to_summonai_outside_tmux(self):
         payload = {}
         with mock.patch.dict("os.environ", {}, clear=True):
-            self.assertEqual(session_start_memory_context.resolve_agent_id(payload), "default")
+            self.assertEqual(session_start_memory_context.resolve_agent_id(payload), "summonai")
 
     def test_resolve_role_and_task_id_without_zellij_pane_id_uses_env_fallback(self):
         env = {"SUMMONAI_ROLE": "interface", "SUMMONAI_TASK_ID": "task_from_env"}

--- a/memory-mcp/tests/test_stop_hook_conversation_save.py
+++ b/memory-mcp/tests/test_stop_hook_conversation_save.py
@@ -20,7 +20,7 @@ import stop_hook_conversation_save  # noqa: E402
 
 
 class StopHookConversationSaveTest(unittest.TestCase):
-    def test_main_defaults_agent_id_to_default_when_unset(self):
+    def test_main_defaults_agent_id_to_summonai_when_unset(self):
         payload = {"transcript": "assistant: hello"}
 
         with mock.patch.dict("os.environ", {}, clear=True):
@@ -45,7 +45,7 @@ class StopHookConversationSaveTest(unittest.TestCase):
 
         self.assertEqual(rc, 0)
         self.assertEqual(stdout.getvalue().strip(), "saved")
-        self.assertEqual(save_mock.call_args.kwargs["agent_id"], "default")
+        self.assertEqual(save_mock.call_args.kwargs["agent_id"], "summonai")
 
     def test_main_uses_agent_id_from_runtime_config(self):
         payload = {"transcript": "assistant: hello"}


### PR DESCRIPTION
## Summary
- apply TRI rank multiplier in `memory-mcp/server.py::_recall_search` using existing score helpers
- increase passive recall vector candidate size from 8 to 20
- keep semantic threshold filtering on raw cosine similarity before TRI re-rank
- add recall TRI ordering test fixture that verifies similarity-only order differs from TRI order
- align two hook tests with current `resolve_agent_id` default (`summonai`)

## Test
- pytest -q memory-mcp/tests
