### PR TITLE
Extract TRI rank_multiplier helper and unify memory/recall scoring

### DIFF
--- a/memory-mcp/server.py
+++ b/memory-mcp/server.py
@@ -572,6 +572,29 @@ def _memory_ranked_score(row: sqlite3.Row) -> float:
 def _memory_impact_score(row: sqlite3.Row) -> float:
     return _clamp(abs(float(row["emotional_impact"] or 0.0)) / 10.0, 0.0, 1.0)
 
+
+def _compute_rank_multiplier(
+    row: sqlite3.Row,
+    now: datetime,
+    include_future: bool = True,
+) -> float:
+    validity_score = _memory_validity_score(
+        row["valid_from"] if "valid_from" in row.keys() else None,
+        row["valid_until"] if "valid_until" in row.keys() else None,
+        now,
+        include_future=include_future,
+    )
+    recency_score = _memory_recency_score(
+        row["last_accessed_at"] if "last_accessed_at" in row.keys() else None,
+        row["created_at"] if "created_at" in row.keys() else None,
+        now,
+    )
+    temporal_score = 0.7 * validity_score + 0.3 * recency_score
+    ranked_score = _memory_ranked_score(row)
+    impact_score = _memory_impact_score(row)
+    return 1 + 0.30 * ranked_score + 0.18 * temporal_score + 0.12 * impact_score
+
+
 def _normalize_relation_type(relation_type: str) -> str:
     normalized = (relation_type or "").strip().lower()
     if normalized not in _MEMORY_LINK_RELATION_TYPES:
@@ -1016,21 +1039,11 @@ def memory_search(
             lexical_score = lexical_scores.get(memory_id, 0.0)
             semantic_score = semantic_scores.get(memory_id, 0.0)
             base_score = 0.55 * lexical_score + 0.45 * semantic_score
-            validity_score = _memory_validity_score(
-                row["valid_from"] if "valid_from" in row.keys() else None,
-                row["valid_until"],
+            rank_multiplier = _compute_rank_multiplier(
+                row,
                 now,
                 include_future=include_future,
             )
-            recency_score = _memory_recency_score(
-                row["last_accessed_at"] if "last_accessed_at" in row.keys() else None,
-                row["created_at"],
-                now,
-            )
-            temporal_score = 0.7 * validity_score + 0.3 * recency_score
-            ranked_score = _memory_ranked_score(row)
-            impact_score = _memory_impact_score(row)
-            rank_multiplier = 1 + 0.30 * ranked_score + 0.18 * temporal_score + 0.12 * impact_score
             bucket_multiplier = _BUCKET_MULTIPLIER.get(row["memory_bucket"] or "knowledge", 1.0)
             base_scores[memory_id] = base_score
             tri_core_scores[memory_id] = base_score * rank_multiplier * bucket_multiplier
@@ -1069,21 +1082,11 @@ def memory_search(
                         lexical_score = lexical_scores.get(target_id, 0.0)
                         semantic_score = semantic_scores.get(target_id, 0.0)
                         base_score = 0.55 * lexical_score + 0.45 * semantic_score
-                        validity_score = _memory_validity_score(
-                            row["valid_from"] if "valid_from" in row.keys() else None,
-                            row["valid_until"],
+                        rank_multiplier = _compute_rank_multiplier(
+                            row,
                             now,
                             include_future=include_future,
                         )
-                        recency_score = _memory_recency_score(
-                            row["last_accessed_at"] if "last_accessed_at" in row.keys() else None,
-                            row["created_at"],
-                            now,
-                        )
-                        temporal_score = 0.7 * validity_score + 0.3 * recency_score
-                        ranked_score = _memory_ranked_score(row)
-                        impact_score = _memory_impact_score(row)
-                        rank_multiplier = 1 + 0.30 * ranked_score + 0.18 * temporal_score + 0.12 * impact_score
                         bucket_multiplier = _BUCKET_MULTIPLIER.get(row["memory_bucket"] or "knowledge", 1.0)
                         base_scores[target_id] = base_score
                         tri_core_scores[target_id] = base_score * rank_multiplier * bucket_multiplier
@@ -1713,14 +1716,7 @@ def _recall_search(prompt_text: str) -> list[tuple[int, str, float]]:
                 ).fetchone()
                 if not memory_row:
                     continue
-                ranked_score = _memory_ranked_score(memory_row)
-                temporal_score = _memory_recency_score(
-                    memory_row["last_accessed_at"],
-                    memory_row["created_at"],
-                    now,
-                )
-                impact_score = _memory_impact_score(memory_row)
-                rank_multiplier = 1 + 0.30 * ranked_score + 0.18 * temporal_score + 0.12 * impact_score
+                rank_multiplier = _compute_rank_multiplier(memory_row, now)
                 candidates.append((mid, sim, sim * rank_multiplier))
 
         candidates.sort(key=lambda x: x[2], reverse=True)

--- a/memory-mcp/tests/test_conversation_memory.py
+++ b/memory-mcp/tests/test_conversation_memory.py
@@ -987,6 +987,114 @@ assistant: old chunk must disappear
         self.assertEqual(similarity_only_order, [2, 1, 4, 3])
         self.assertNotEqual(tri_order, similarity_only_order)
 
+    def test_rank_multiplier_matches_between_memory_search_and_recall_search(self):
+        content = "tri multiplier parity anchor"
+        self.server.memory_save(
+            content=content,
+            memory_type="semantic",
+            memory_bucket="knowledge",
+            category="test",
+            source_agent="worker6",
+            tags_csv="tri:parity",
+            importance=8,
+            confidence=0.9,
+            emotional_impact=4.0,
+        )
+
+        now_ts = datetime.now().isoformat(timespec="seconds")
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            conn.execute(
+                """
+                UPDATE memories
+                SET access_count = 5, recall_count = 3, last_accessed_at = ?, valid_until = NULL
+                WHERE content = ?
+                """,
+                (now_ts, content),
+            )
+            row = conn.execute(
+                "SELECT * FROM memories WHERE content = ? ORDER BY id DESC LIMIT 1",
+                (content,),
+            ).fetchone()
+            self.assertIsNotNone(row)
+            memory_id = int(row["id"])
+            row_dict = dict(row)
+        finally:
+            conn.commit()
+            conn.close()
+
+        original_compute = self.server._compute_rank_multiplier
+        from_memory_search: list[float] = []
+
+        def _capture_memory_search(rank_row, now, include_future=True):
+            value = original_compute(rank_row, now, include_future=include_future)
+            if int(rank_row["id"]) == memory_id:
+                from_memory_search.append(value)
+            return value
+
+        with mock.patch.object(
+            self.server, "_compute_rank_multiplier", side_effect=_capture_memory_search
+        ):
+            raw = self.server.memory_search(
+                query=content,
+                top_k=1,
+                include_future=False,
+                enable_spreading=False,
+            )
+        rows = json.loads(raw)
+        self.assertGreaterEqual(len(rows), 1)
+        self.assertEqual(rows[0]["id"], memory_id)
+        self.assertEqual(len(from_memory_search), 1)
+
+        prompt_vec = self.server.np.array([1.0, 0.0], dtype=self.server.np.float32)
+        embedding = self.server.np.array([0.99, 0.14106736], dtype=self.server.np.float32).tobytes()
+        from_recall_search: list[float] = []
+
+        class _FakeCursor:
+            def __init__(self, rows):
+                self._rows = rows
+
+            def fetchall(self):
+                return self._rows
+
+            def fetchone(self):
+                return self._rows[0] if self._rows else None
+
+        class _FakeConn:
+            def execute(self, sql, params=()):
+                if "FROM memories_vec mv" in sql:
+                    return _FakeCursor([{"memory_id": memory_id}])
+                if "SELECT embedding FROM memories_vec" in sql:
+                    return _FakeCursor([{"embedding": embedding}])
+                if "SELECT content, importance, confidence, access_count, recall_count" in sql:
+                    return _FakeCursor([row_dict])
+                if "SELECT content FROM memories" in sql:
+                    return _FakeCursor([{"content": content}])
+                raise AssertionError(f"unexpected query: {sql}")
+
+            def close(self):
+                return None
+
+        def _capture_recall_search(rank_row, now, include_future=True):
+            value = original_compute(rank_row, now, include_future=include_future)
+            from_recall_search.append(value)
+            return value
+
+        with mock.patch.object(self.server, "get_db", return_value=_FakeConn()), \
+             mock.patch.object(self.server, "_embed_model") as mock_model, \
+             mock.patch.object(self.server, "_RECALL_TOP_K", 1), \
+             mock.patch.object(self.server, "_RECALL_TOKEN_BUDGET", 10_000), \
+             mock.patch.object(self.server, "_RECALL_SIM_THRESHOLD", 0.1), \
+             mock.patch.object(self.server, "_compute_rank_multiplier", side_effect=_capture_recall_search):
+            mock_model.encode.return_value = prompt_vec
+            recall_rows = self.server._recall_search(content)
+
+        self.assertGreaterEqual(len(recall_rows), 1)
+        self.assertEqual(recall_rows[0][0], memory_id)
+        self.assertEqual(len(from_recall_search), 1)
+        self.assertEqual(from_memory_search[0], from_recall_search[0])
+
     def test_memory_load_returns_min_fields_and_normalizes_newlines_in_response_only(self):
         multiline = "load line1\nload line2"
         self.server.memory_save(


### PR DESCRIPTION
## Summary
- add `_compute_rank_multiplier(row, now, include_future=True)` in `memory-mcp/server.py`
- replace duplicated rank_multiplier computations in `memory_search` direct candidates and spreading-activation candidates with the shared helper
- replace `_recall_search` rank_multiplier computation with the shared helper so temporal score uses `0.7 * validity + 0.3 * recency`
- add regression test to assert the same memory row yields exactly identical rank_multiplier values between `memory_search` and `_recall_search`

## Verification
- `cd memory-mcp && python -m unittest discover -s tests -p 'test_*.py'`
- `ulimit -n 4096 && python -m pytest -q task-mcp/tests`